### PR TITLE
fix: checkPathParamExists rule

### DIFF
--- a/definitions/syntetic/syntetic-1.yaml
+++ b/definitions/syntetic/syntetic-1.yaml
@@ -39,6 +39,24 @@ paths:
             application/json:
               schema:
                 type: object
+  '/user/{id}':
+    get:
+      parameters:
+        - in: path
+          name: test
+          description: User id
+          required: true
+          schema:
+            type: string
+      operationId: withPathParam
+      description: Get user by id
+      responses:
+        '200':
+          description: example description
+          content:
+            application/json:
+              schema:
+                type: object
 externalDocs:
   description:
     $ref: inc/docs-description.md

--- a/src/__tests__/validate.test.js
+++ b/src/__tests__/validate.test.js
@@ -9,21 +9,86 @@ describe("Traverse files", () => {
       .toMatchInlineSnapshot(`
       Array [
         Object {
-          "codeFrame": "[90m57|   parameters:[39m
-      [90m58|     example:[39m
-      [90m59|       [4m[31mallOf[90m[24m:[39m
-      [90m60|         - name: bla[39m
-      [90m61|           in: query[39m",
+          "codeFrame": "[90m74|       bearerFormat: JWT[39m
+      [90m75|   parameters:[39m
+      [90m76|     [4m[31mexample:[90m[24m[39m
+      [90m77|[39m[31m [4m[31m      allOf:[31m[24m[39m
+      [90m78|[39m[31m [4m[31m        - name: bla[31m[24m[39m
+      [90m79|[39m[31m [4m[31m          in: query[31m[24m[39m
+      [90m80|[39m[31m [4m[31m          required: false[31m[24m[39m
+      [90m81|[39m[31m [4m[31m          schema:[31m[24m[39m
+      [90m82|[39m[31m [4m[31m            type: string[31m[24m[39m
+      [90m83|[39m[31m [4m[31m        - description: blo[31m[24m[39m
+      [90m84|[39m[31m [4m[31m        - description: bla[31m[24m[39m
+      [90m85| [4m[31m    [90m[24mgenericExample:[39m
+      [90m86|       name: example[39m
+      [90m87|       in: query[39m",
+          "enableCodeframe": true,
+          "file": "definitions/syntetic/syntetic-1.yaml",
+          "fromRule": "path-param-exists",
+          "location": Object {
+            "endCol": 5,
+            "endIndex": 1894,
+            "endLine": 85,
+            "startCol": 5,
+            "startIndex": 1705,
+            "startLine": 76,
+          },
+          "message": "The \\"name\\" field value is not in the current path.",
+          "path": Array [
+            "components",
+            "parameters",
+            "example",
+            "name",
+          ],
+          "possibleAlternate": undefined,
+          "referencedFrom": Object {
+            "file": "definitions/syntetic/syntetic-1.yaml",
+            "path": Array [
+              "paths",
+              "user",
+              "parameters",
+              0,
+            ],
+            "startLine": 20,
+          },
+          "severity": 4,
+          "target": "value",
+          "value": Object {
+            "allOf": Array [
+              Object {
+                "in": "query",
+                "name": "bla",
+                "required": false,
+                "schema": Object {
+                  "type": "string",
+                },
+              },
+              Object {
+                "description": "blo",
+              },
+              Object {
+                "description": "bla",
+              },
+            ],
+          },
+        },
+        Object {
+          "codeFrame": "[90m75|   parameters:[39m
+      [90m76|     example:[39m
+      [90m77|       [4m[31mallOf[90m[24m:[39m
+      [90m78|         - name: bla[39m
+      [90m79|           in: query[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "no-extra-fields",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1301,
-            "endLine": 59,
+            "endIndex": 1725,
+            "endLine": 77,
             "startCol": 7,
-            "startIndex": 1296,
-            "startLine": 59,
+            "startIndex": 1720,
+            "startLine": 77,
           },
           "message": "The field 'allOf' is not allowed in OpenAPIParameter. Use \\"x-\\" prefix or custom types to override this behavior.",
           "path": Array [
@@ -67,21 +132,21 @@ describe("Traverse files", () => {
           },
         },
         Object {
-          "codeFrame": "[90m56|       bearerFormat: JWT[39m
-      [90m57|   parameters:[39m
-      [90m58|     [4m[31mexample[90m[24m:[39m
-      [90m59|       allOf:[39m
-      [90m60|         - name: bla[39m",
+          "codeFrame": "[90m74|       bearerFormat: JWT[39m
+      [90m75|   parameters:[39m
+      [90m76|     [4m[31mexample[90m[24m:[39m
+      [90m77|       allOf:[39m
+      [90m78|         - name: bla[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "oas3-schema/parameter",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1288,
-            "endLine": 58,
+            "endIndex": 1712,
+            "endLine": 76,
             "startCol": 5,
-            "startIndex": 1281,
-            "startLine": 58,
+            "startIndex": 1705,
+            "startLine": 76,
           },
           "message": "The field 'name' must be present on this level.",
           "path": Array [
@@ -123,21 +188,21 @@ describe("Traverse files", () => {
           },
         },
         Object {
-          "codeFrame": "[90m56|       bearerFormat: JWT[39m
-      [90m57|   parameters:[39m
-      [90m58|     [4m[31mexample[90m[24m:[39m
-      [90m59|       allOf:[39m
-      [90m60|         - name: bla[39m",
+          "codeFrame": "[90m74|       bearerFormat: JWT[39m
+      [90m75|   parameters:[39m
+      [90m76|     [4m[31mexample[90m[24m:[39m
+      [90m77|       allOf:[39m
+      [90m78|         - name: bla[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "oas3-schema/parameter",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1288,
-            "endLine": 58,
+            "endIndex": 1712,
+            "endLine": 76,
             "startCol": 5,
-            "startIndex": 1281,
-            "startLine": 58,
+            "startIndex": 1705,
+            "startLine": 76,
           },
           "message": "The field 'in' must be present on this level.",
           "path": Array [
@@ -179,21 +244,61 @@ describe("Traverse files", () => {
           },
         },
         Object {
-          "codeFrame": "[90m57|   parameters:[39m
-      [90m58|     example:[39m
-      [90m59|       [4m[31mallOf[90m[24m:[39m
-      [90m60|         - name: bla[39m
-      [90m61|           in: query[39m",
+          "codeFrame": "[90m44|       parameters:[39m
+      [90m45|         - in: path[39m
+      [90m46|           [4m[31mname: test[90m[24m[39m
+      [90m47|           description: User id[39m
+      [90m48|           required: true[39m",
+          "enableCodeframe": true,
+          "file": "definitions/syntetic/syntetic-1.yaml",
+          "fromRule": "path-param-exists",
+          "location": Object {
+            "endCol": 20,
+            "endIndex": 939,
+            "endLine": 46,
+            "startCol": 11,
+            "startIndex": 929,
+            "startLine": 46,
+          },
+          "message": "The \\"name\\" field value is not in the current path.",
+          "path": Array [
+            "paths",
+            "/user/{id}",
+            "get",
+            "parameters",
+            0,
+            "name",
+          ],
+          "possibleAlternate": undefined,
+          "referencedFrom": null,
+          "severity": 4,
+          "target": "value",
+          "value": Object {
+            "description": "User id",
+            "in": "path",
+            "name": "test",
+            "required": true,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+        },
+        Object {
+          "codeFrame": "[90m75|   parameters:[39m
+      [90m76|     example:[39m
+      [90m77|       [4m[31mallOf[90m[24m:[39m
+      [90m78|         - name: bla[39m
+      [90m79|           in: query[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "no-extra-fields",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1301,
-            "endLine": 59,
+            "endIndex": 1725,
+            "endLine": 77,
             "startCol": 7,
-            "startIndex": 1296,
-            "startLine": 59,
+            "startIndex": 1720,
+            "startLine": 77,
           },
           "message": "The field 'allOf' is not allowed in OpenAPIParameter. Use \\"x-\\" prefix or custom types to override this behavior.",
           "path": Array [
@@ -228,21 +333,21 @@ describe("Traverse files", () => {
           },
         },
         Object {
-          "codeFrame": "[90m56|       bearerFormat: JWT[39m
-      [90m57|   parameters:[39m
-      [90m58|     [4m[31mexample[90m[24m:[39m
-      [90m59|       allOf:[39m
-      [90m60|         - name: bla[39m",
+          "codeFrame": "[90m74|       bearerFormat: JWT[39m
+      [90m75|   parameters:[39m
+      [90m76|     [4m[31mexample[90m[24m:[39m
+      [90m77|       allOf:[39m
+      [90m78|         - name: bla[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "oas3-schema/parameter",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1288,
-            "endLine": 58,
+            "endIndex": 1712,
+            "endLine": 76,
             "startCol": 5,
-            "startIndex": 1281,
-            "startLine": 58,
+            "startIndex": 1705,
+            "startLine": 76,
           },
           "message": "The field 'name' must be present on this level.",
           "path": Array [
@@ -275,21 +380,21 @@ describe("Traverse files", () => {
           },
         },
         Object {
-          "codeFrame": "[90m56|       bearerFormat: JWT[39m
-      [90m57|   parameters:[39m
-      [90m58|     [4m[31mexample[90m[24m:[39m
-      [90m59|       allOf:[39m
-      [90m60|         - name: bla[39m",
+          "codeFrame": "[90m74|       bearerFormat: JWT[39m
+      [90m75|   parameters:[39m
+      [90m76|     [4m[31mexample[90m[24m:[39m
+      [90m77|       allOf:[39m
+      [90m78|         - name: bla[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "oas3-schema/parameter",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1288,
-            "endLine": 58,
+            "endIndex": 1712,
+            "endLine": 76,
             "startCol": 5,
-            "startIndex": 1281,
-            "startLine": 58,
+            "startIndex": 1705,
+            "startLine": 76,
           },
           "message": "The field 'in' must be present on this level.",
           "path": Array [
@@ -322,21 +427,21 @@ describe("Traverse files", () => {
           },
         },
         Object {
-          "codeFrame": "[90m43|   description:[39m
-      [90m44|     $ref: inc/docs-description.md[39m
-      [90m45|   [4m[31murl: googlecom[90m[24m[39m
-      [90m46| components:[39m
-      [90m47|   securitySchemes:[39m",
+          "codeFrame": "[90m61|   description:[39m
+      [90m62|     $ref: inc/docs-description.md[39m
+      [90m63|   [4m[31murl: googlecom[90m[24m[39m
+      [90m64| components:[39m
+      [90m65|   securitySchemes:[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "oas3-schema/external-docs",
           "location": Object {
             "endCol": 16,
-            "endIndex": 936,
-            "endLine": 45,
+            "endIndex": 1360,
+            "endLine": 63,
             "startCol": 3,
-            "startIndex": 922,
-            "startLine": 45,
+            "startIndex": 1346,
+            "startLine": 63,
           },
           "message": "url must be a valid URL",
           "path": Array [
@@ -382,21 +487,86 @@ describe("Traverse files", () => {
       .toMatchInlineSnapshot(`
       Array [
         Object {
-          "codeFrame": "[90m57|   parameters:[39m
-      [90m58|     example:[39m
-      [90m59|       [4m[31mallOf[90m[24m:[39m
-      [90m60|         - name: bla[39m
-      [90m61|           in: query[39m",
+          "codeFrame": "[90m74|       bearerFormat: JWT[39m
+      [90m75|   parameters:[39m
+      [90m76|     [4m[31mexample:[90m[24m[39m
+      [90m77|[39m[31m [4m[31m      allOf:[31m[24m[39m
+      [90m78|[39m[31m [4m[31m        - name: bla[31m[24m[39m
+      [90m79|[39m[31m [4m[31m          in: query[31m[24m[39m
+      [90m80|[39m[31m [4m[31m          required: false[31m[24m[39m
+      [90m81|[39m[31m [4m[31m          schema:[31m[24m[39m
+      [90m82|[39m[31m [4m[31m            type: string[31m[24m[39m
+      [90m83|[39m[31m [4m[31m        - description: blo[31m[24m[39m
+      [90m84|[39m[31m [4m[31m        - description: bla[31m[24m[39m
+      [90m85| [4m[31m    [90m[24mgenericExample:[39m
+      [90m86|       name: example[39m
+      [90m87|       in: query[39m",
+          "enableCodeframe": true,
+          "file": "definitions/syntetic/syntetic-1.yaml",
+          "fromRule": "path-param-exists",
+          "location": Object {
+            "endCol": 5,
+            "endIndex": 1894,
+            "endLine": 85,
+            "startCol": 5,
+            "startIndex": 1705,
+            "startLine": 76,
+          },
+          "message": "The \\"name\\" field value is not in the current path.",
+          "path": Array [
+            "components",
+            "parameters",
+            "example",
+            "name",
+          ],
+          "possibleAlternate": undefined,
+          "referencedFrom": Object {
+            "file": "definitions/syntetic/syntetic-1.yaml",
+            "path": Array [
+              "paths",
+              "user",
+              "parameters",
+              0,
+            ],
+            "startLine": 20,
+          },
+          "severity": 4,
+          "target": "value",
+          "value": Object {
+            "allOf": Array [
+              Object {
+                "in": "query",
+                "name": "bla",
+                "required": false,
+                "schema": Object {
+                  "type": "string",
+                },
+              },
+              Object {
+                "description": "blo",
+              },
+              Object {
+                "description": "bla",
+              },
+            ],
+          },
+        },
+        Object {
+          "codeFrame": "[90m75|   parameters:[39m
+      [90m76|     example:[39m
+      [90m77|       [4m[31mallOf[90m[24m:[39m
+      [90m78|         - name: bla[39m
+      [90m79|           in: query[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "no-extra-fields",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1301,
-            "endLine": 59,
+            "endIndex": 1725,
+            "endLine": 77,
             "startCol": 7,
-            "startIndex": 1296,
-            "startLine": 59,
+            "startIndex": 1720,
+            "startLine": 77,
           },
           "message": "The field 'allOf' is not allowed in OpenAPIParameter. Use \\"x-\\" prefix or custom types to override this behavior.",
           "path": Array [
@@ -440,21 +610,21 @@ describe("Traverse files", () => {
           },
         },
         Object {
-          "codeFrame": "[90m56|       bearerFormat: JWT[39m
-      [90m57|   parameters:[39m
-      [90m58|     [4m[31mexample[90m[24m:[39m
-      [90m59|       allOf:[39m
-      [90m60|         - name: bla[39m",
+          "codeFrame": "[90m74|       bearerFormat: JWT[39m
+      [90m75|   parameters:[39m
+      [90m76|     [4m[31mexample[90m[24m:[39m
+      [90m77|       allOf:[39m
+      [90m78|         - name: bla[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "oas3-schema/parameter",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1288,
-            "endLine": 58,
+            "endIndex": 1712,
+            "endLine": 76,
             "startCol": 5,
-            "startIndex": 1281,
-            "startLine": 58,
+            "startIndex": 1705,
+            "startLine": 76,
           },
           "message": "The field 'name' must be present on this level.",
           "path": Array [
@@ -496,21 +666,21 @@ describe("Traverse files", () => {
           },
         },
         Object {
-          "codeFrame": "[90m56|       bearerFormat: JWT[39m
-      [90m57|   parameters:[39m
-      [90m58|     [4m[31mexample[90m[24m:[39m
-      [90m59|       allOf:[39m
-      [90m60|         - name: bla[39m",
+          "codeFrame": "[90m74|       bearerFormat: JWT[39m
+      [90m75|   parameters:[39m
+      [90m76|     [4m[31mexample[90m[24m:[39m
+      [90m77|       allOf:[39m
+      [90m78|         - name: bla[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "oas3-schema/parameter",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1288,
-            "endLine": 58,
+            "endIndex": 1712,
+            "endLine": 76,
             "startCol": 5,
-            "startIndex": 1281,
-            "startLine": 58,
+            "startIndex": 1705,
+            "startLine": 76,
           },
           "message": "The field 'in' must be present on this level.",
           "path": Array [
@@ -552,21 +722,61 @@ describe("Traverse files", () => {
           },
         },
         Object {
-          "codeFrame": "[90m57|   parameters:[39m
-      [90m58|     example:[39m
-      [90m59|       [4m[31mallOf[90m[24m:[39m
-      [90m60|         - name: bla[39m
-      [90m61|           in: query[39m",
+          "codeFrame": "[90m44|       parameters:[39m
+      [90m45|         - in: path[39m
+      [90m46|           [4m[31mname: test[90m[24m[39m
+      [90m47|           description: User id[39m
+      [90m48|           required: true[39m",
+          "enableCodeframe": true,
+          "file": "definitions/syntetic/syntetic-1.yaml",
+          "fromRule": "path-param-exists",
+          "location": Object {
+            "endCol": 20,
+            "endIndex": 939,
+            "endLine": 46,
+            "startCol": 11,
+            "startIndex": 929,
+            "startLine": 46,
+          },
+          "message": "The \\"name\\" field value is not in the current path.",
+          "path": Array [
+            "paths",
+            "/user/{id}",
+            "get",
+            "parameters",
+            0,
+            "name",
+          ],
+          "possibleAlternate": undefined,
+          "referencedFrom": null,
+          "severity": 4,
+          "target": "value",
+          "value": Object {
+            "description": "User id",
+            "in": "path",
+            "name": "test",
+            "required": true,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+        },
+        Object {
+          "codeFrame": "[90m75|   parameters:[39m
+      [90m76|     example:[39m
+      [90m77|       [4m[31mallOf[90m[24m:[39m
+      [90m78|         - name: bla[39m
+      [90m79|           in: query[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "no-extra-fields",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1301,
-            "endLine": 59,
+            "endIndex": 1725,
+            "endLine": 77,
             "startCol": 7,
-            "startIndex": 1296,
-            "startLine": 59,
+            "startIndex": 1720,
+            "startLine": 77,
           },
           "message": "The field 'allOf' is not allowed in OpenAPIParameter. Use \\"x-\\" prefix or custom types to override this behavior.",
           "path": Array [
@@ -601,21 +811,21 @@ describe("Traverse files", () => {
           },
         },
         Object {
-          "codeFrame": "[90m56|       bearerFormat: JWT[39m
-      [90m57|   parameters:[39m
-      [90m58|     [4m[31mexample[90m[24m:[39m
-      [90m59|       allOf:[39m
-      [90m60|         - name: bla[39m",
+          "codeFrame": "[90m74|       bearerFormat: JWT[39m
+      [90m75|   parameters:[39m
+      [90m76|     [4m[31mexample[90m[24m:[39m
+      [90m77|       allOf:[39m
+      [90m78|         - name: bla[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "oas3-schema/parameter",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1288,
-            "endLine": 58,
+            "endIndex": 1712,
+            "endLine": 76,
             "startCol": 5,
-            "startIndex": 1281,
-            "startLine": 58,
+            "startIndex": 1705,
+            "startLine": 76,
           },
           "message": "The field 'name' must be present on this level.",
           "path": Array [
@@ -648,21 +858,21 @@ describe("Traverse files", () => {
           },
         },
         Object {
-          "codeFrame": "[90m56|       bearerFormat: JWT[39m
-      [90m57|   parameters:[39m
-      [90m58|     [4m[31mexample[90m[24m:[39m
-      [90m59|       allOf:[39m
-      [90m60|         - name: bla[39m",
+          "codeFrame": "[90m74|       bearerFormat: JWT[39m
+      [90m75|   parameters:[39m
+      [90m76|     [4m[31mexample[90m[24m:[39m
+      [90m77|       allOf:[39m
+      [90m78|         - name: bla[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "oas3-schema/parameter",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1288,
-            "endLine": 58,
+            "endIndex": 1712,
+            "endLine": 76,
             "startCol": 5,
-            "startIndex": 1281,
-            "startLine": 58,
+            "startIndex": 1705,
+            "startLine": 76,
           },
           "message": "The field 'in' must be present on this level.",
           "path": Array [
@@ -695,21 +905,21 @@ describe("Traverse files", () => {
           },
         },
         Object {
-          "codeFrame": "[90m43|   description:[39m
-      [90m44|     $ref: inc/docs-description.md[39m
-      [90m45|   [4m[31murl: googlecom[90m[24m[39m
-      [90m46| components:[39m
-      [90m47|   securitySchemes:[39m",
+          "codeFrame": "[90m61|   description:[39m
+      [90m62|     $ref: inc/docs-description.md[39m
+      [90m63|   [4m[31murl: googlecom[90m[24m[39m
+      [90m64| components:[39m
+      [90m65|   securitySchemes:[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "oas3-schema/external-docs",
           "location": Object {
             "endCol": 16,
-            "endIndex": 936,
-            "endLine": 45,
+            "endIndex": 1360,
+            "endLine": 63,
             "startCol": 3,
-            "startIndex": 922,
-            "startLine": 45,
+            "startIndex": 1346,
+            "startLine": 63,
           },
           "message": "url must be a valid URL",
           "path": Array [

--- a/src/error/__tests__/default.test.js
+++ b/src/error/__tests__/default.test.js
@@ -227,6 +227,35 @@ describe("fromError", () => {
               },
               "openapi": "3.0.2",
               "paths": Object {
+                "/user/{id}": Object {
+                  "get": Object {
+                    "description": "Get user by id",
+                    "operationId": "withPathParam",
+                    "parameters": Array [
+                      Object {
+                        "description": "User id",
+                        "in": "path",
+                        "name": "test",
+                        "required": true,
+                        "schema": Object {
+                          "type": "string",
+                        },
+                      },
+                    ],
+                    "responses": Object {
+                      "200": Object {
+                        "content": Object {
+                          "application/json": Object {
+                            "schema": Object {
+                              "type": "object",
+                            },
+                          },
+                        },
+                        "description": "example description",
+                      },
+                    },
+                  },
+                },
                 "project": Object {
                   "get": Object {
                     "description": "Get project",
@@ -316,6 +345,24 @@ describe("fromError", () => {
           get:
             operationId: projectGet
             description: Get project
+            responses:
+              '200':
+                description: example description
+                content:
+                  application/json:
+                    schema:
+                      type: object
+        '/user/{id}':
+          get:
+            parameters:
+              - in: path
+                name: test
+                description: User id
+                required: true
+                schema:
+                  type: string
+            operationId: withPathParam
+            description: Get user by id
             responses:
               '200':
                 description: example description

--- a/src/visitors/rules/semantic/checkPathParamExists.js
+++ b/src/visitors/rules/semantic/checkPathParamExists.js
@@ -12,7 +12,7 @@ class CheckPathParamExists {
 
         if (isPathParameter) {
           const visitedNodes = ctx.pathStack.reduce((acc, val) => [...acc, ...(val.path)], []);
-          const isInPath = visitedNodes.includes('paths');
+          const isInPath = visitedNodes.length > 0 && visitedNodes[0] === 'paths';
 
           if (isInPath) {
             const missingNameInPath = [...ctx.path, ...visitedNodes]

--- a/src/visitors/rules/semantic/checkPathParamExists.js
+++ b/src/visitors/rules/semantic/checkPathParamExists.js
@@ -7,16 +7,23 @@ class CheckPathParamExists {
     return {
       onEnter: (node, definition, ctx) => {
         const errors = [];
-        if (node.in && node.in === 'path') {
+
+        const isPathParameter = node.in && node.in === 'path';
+
+        if (isPathParameter) {
           const visitedNodes = ctx.pathStack.reduce((acc, val) => [...acc, ...(val.path)], []);
-          const missingNameInPath = [...ctx.path, ...visitedNodes]
-            .filter((pathNode) => typeof pathNode === 'string' && pathNode.indexOf(`{${node.name}}`) !== -1)
-            .length === 0
-              && (ctx.path.indexOf('components') === -1 || visitedNodes.indexOf('paths') !== -1);
-          if (missingNameInPath) {
-            ctx.path.push('name');
-            errors.push(ctx.createError('The "name" field value is not in the current parameter path.', 'value'));
-            ctx.path.pop();
+          const isInPath = visitedNodes.includes('paths');
+
+          if (isInPath) {
+            const missingNameInPath = [...ctx.path, ...visitedNodes]
+              .filter((pathNode) => typeof pathNode === 'string' && pathNode.indexOf(`{${node.name}}`) !== -1)
+              .length === 0;
+
+            if (missingNameInPath) {
+              ctx.path.push('name');
+              errors.push(ctx.createError('The "name" field value is not in the current parameter path.', 'value'));
+              ctx.path.pop();
+            }
           }
         }
         return errors;
@@ -24,5 +31,4 @@ class CheckPathParamExists {
     };
   }
 }
-
 module.exports = CheckPathParamExists;


### PR DESCRIPTION
Rule was assuming that all of our paths were stored in a dereferenced openapi file rather than being a $ref. This should cover both cases now.