### PR TITLE
fix: do not crash when `--output` is not specified

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -55,7 +55,7 @@ const cli = () => {
 
       const isOutputDir = cmdObj.output && !extname(cmdObj.output);
       const ext = cmdObj.ext || extname(cmdObj.output || '').substring(1) || 'yaml';
-      const dir = isOutputDir ? cmdObj.output : dirname(cmdObj.output);
+      const dir = isOutputDir ? cmdObj.output : dirname(cmdObj.output || '');
 
       const results = {
         errors: 0,
@@ -63,10 +63,13 @@ const cli = () => {
       };
 
       entryPoints.forEach((entryPoint) => {
-        const fileName = isOutputDir
-          ? basename(entryPoint, extname(entryPoint))
-          : basename(cmdObj.output, `.${ext}`);
-        const output = join(dir, `${fileName}.${ext}`);
+        let output;
+        if (cmdObj.output) {
+          const fileName = isOutputDir
+            ? basename(entryPoint, extname(entryPoint))
+            : basename(cmdObj.output, `.${ext}`);
+          output = join(dir, `${fileName}.${ext}`);
+        }
 
         const bundlingStatus = bundleToFile(entryPoint, output);
         const resultStats = outputMessages(bundlingStatus, cmdObj);
@@ -77,7 +80,7 @@ const cli = () => {
             process.stdout.write(`Created a bundle for ${entryPoint} at ${output}.\n`);
           }
         } else {
-          process.stdout.write(`Errors encountered while bundling ${entryPoint}.\n`);
+          process.stderr.write(`Errors encountered while bundling ${entryPoint}.\n`);
           results.errors += resultStats.totalErrors;
           results.warnings += resultStats.totalWarnings;
         }

--- a/src/cli/outputMessages.js
+++ b/src/cli/outputMessages.js
@@ -109,21 +109,21 @@ export const outputMessages = (result, cmdObj) => {
       .length;
 
     Object.keys(groupedByFile).forEach((fileName) => {
-      process.stdout.write(`${outputUnderline(`${path.relative(process.cwd(), fileName)}:\n`)}`);
+      process.stderr.write(`${outputUnderline(`${path.relative(process.cwd(), fileName)}:\n`)}`);
       groupedByFile[fileName]
         .sort((a, b) => a.severity < b.severity)
         .forEach(
-          (entry, id) => process.stdout.write(
+          (entry, id) => process.stderr.write(
             prettyPrintShort(id + 1, entry, posLength, longestRuleName),
           ),
         );
-      process.stdout.write('\n');
+      process.stderr.write('\n');
     });
   } else {
-    if (errorsGrouped.length > 0) process.stdout.write('\n\n');
+    if (errorsGrouped.length > 0) process.stderr.write('\n\n');
     errorsGrouped
       .sort((a, b) => a.severity < b.severity)
-      .forEach((entry, id) => process.stdout.write(prettyPrint(id + 1, entry)));
+      .forEach((entry, id) => process.stderr.write(prettyPrint(id + 1, entry)));
   }
 
   return {


### PR DESCRIPTION
There was an issue in bundle cli (introduced by me recently) command so it crashed when `--output` was not specified.

Also, write errors to stderr instead of stdout 