### PR TITLE
feat: allow non-yaml $refs in scalars.

### DIFF
--- a/definitions/syntetic/inc/docs-description.md
+++ b/definitions/syntetic/inc/docs-description.md
@@ -1,0 +1,1 @@
+some test

--- a/definitions/syntetic/inc/docs-description.md
+++ b/definitions/syntetic/inc/docs-description.md
@@ -1,1 +1,9 @@
-some test
+# Test markdown file
+
+This is a test markdown file.
+
+Include it in your OpenAPI definition description like this: 
+
+
+    description:
+      $ref: path/to/file.md

--- a/definitions/syntetic/syntetic-1.yaml
+++ b/definitions/syntetic/syntetic-1.yaml
@@ -40,7 +40,8 @@ paths:
               schema:
                 type: object
 externalDocs:
-  description: asdasd
+  description:
+    $ref: inc/docs-description.md
   url: googlecom
 components:
   securitySchemes:

--- a/src/__tests__/validate.test.js
+++ b/src/__tests__/validate.test.js
@@ -19,10 +19,10 @@ describe("Traverse files", () => {
           "fromRule": "no-extra-fields",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1287,
+            "endIndex": 1301,
             "endLine": 59,
             "startCol": 7,
-            "startIndex": 1282,
+            "startIndex": 1296,
             "startLine": 59,
           },
           "message": "The field 'allOf' is not allowed in OpenAPIParameter. Use \\"x-\\" prefix or custom types to override this behavior.",
@@ -77,10 +77,10 @@ describe("Traverse files", () => {
           "fromRule": "oas3-schema/parameter",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1274,
+            "endIndex": 1288,
             "endLine": 58,
             "startCol": 5,
-            "startIndex": 1267,
+            "startIndex": 1281,
             "startLine": 58,
           },
           "message": "The field 'name' must be present on this level.",
@@ -133,10 +133,10 @@ describe("Traverse files", () => {
           "fromRule": "oas3-schema/parameter",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1274,
+            "endIndex": 1288,
             "endLine": 58,
             "startCol": 5,
-            "startIndex": 1267,
+            "startIndex": 1281,
             "startLine": 58,
           },
           "message": "The field 'in' must be present on this level.",
@@ -189,10 +189,10 @@ describe("Traverse files", () => {
           "fromRule": "no-extra-fields",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1287,
+            "endIndex": 1301,
             "endLine": 59,
             "startCol": 7,
-            "startIndex": 1282,
+            "startIndex": 1296,
             "startLine": 59,
           },
           "message": "The field 'allOf' is not allowed in OpenAPIParameter. Use \\"x-\\" prefix or custom types to override this behavior.",
@@ -238,10 +238,10 @@ describe("Traverse files", () => {
           "fromRule": "oas3-schema/parameter",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1274,
+            "endIndex": 1288,
             "endLine": 58,
             "startCol": 5,
-            "startIndex": 1267,
+            "startIndex": 1281,
             "startLine": 58,
           },
           "message": "The field 'name' must be present on this level.",
@@ -285,10 +285,10 @@ describe("Traverse files", () => {
           "fromRule": "oas3-schema/parameter",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1274,
+            "endIndex": 1288,
             "endLine": 58,
             "startCol": 5,
-            "startIndex": 1267,
+            "startIndex": 1281,
             "startLine": 58,
           },
           "message": "The field 'in' must be present on this level.",
@@ -323,7 +323,7 @@ describe("Traverse files", () => {
         },
         Object {
           "codeFrame": "[90m43|   description:[39m
-      [90m44|     $ref: README.md[39m
+      [90m44|     $ref: inc/docs-description.md[39m
       [90m45|   [4m[31murl: googlecom[90m[24m[39m
       [90m46| components:[39m
       [90m47|   securitySchemes:[39m",
@@ -332,10 +332,10 @@ describe("Traverse files", () => {
           "fromRule": "oas3-schema/external-docs",
           "location": Object {
             "endCol": 16,
-            "endIndex": 922,
+            "endIndex": 936,
             "endLine": 45,
             "startCol": 3,
-            "startIndex": 908,
+            "startIndex": 922,
             "startLine": 45,
           },
           "message": "url must be a valid URL",
@@ -383,10 +383,10 @@ describe("Traverse files", () => {
           "fromRule": "no-extra-fields",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1287,
+            "endIndex": 1301,
             "endLine": 59,
             "startCol": 7,
-            "startIndex": 1282,
+            "startIndex": 1296,
             "startLine": 59,
           },
           "message": "The field 'allOf' is not allowed in OpenAPIParameter. Use \\"x-\\" prefix or custom types to override this behavior.",
@@ -441,10 +441,10 @@ describe("Traverse files", () => {
           "fromRule": "oas3-schema/parameter",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1274,
+            "endIndex": 1288,
             "endLine": 58,
             "startCol": 5,
-            "startIndex": 1267,
+            "startIndex": 1281,
             "startLine": 58,
           },
           "message": "The field 'name' must be present on this level.",
@@ -497,10 +497,10 @@ describe("Traverse files", () => {
           "fromRule": "oas3-schema/parameter",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1274,
+            "endIndex": 1288,
             "endLine": 58,
             "startCol": 5,
-            "startIndex": 1267,
+            "startIndex": 1281,
             "startLine": 58,
           },
           "message": "The field 'in' must be present on this level.",
@@ -553,10 +553,10 @@ describe("Traverse files", () => {
           "fromRule": "no-extra-fields",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1287,
+            "endIndex": 1301,
             "endLine": 59,
             "startCol": 7,
-            "startIndex": 1282,
+            "startIndex": 1296,
             "startLine": 59,
           },
           "message": "The field 'allOf' is not allowed in OpenAPIParameter. Use \\"x-\\" prefix or custom types to override this behavior.",
@@ -602,10 +602,10 @@ describe("Traverse files", () => {
           "fromRule": "oas3-schema/parameter",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1274,
+            "endIndex": 1288,
             "endLine": 58,
             "startCol": 5,
-            "startIndex": 1267,
+            "startIndex": 1281,
             "startLine": 58,
           },
           "message": "The field 'name' must be present on this level.",
@@ -649,10 +649,10 @@ describe("Traverse files", () => {
           "fromRule": "oas3-schema/parameter",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1274,
+            "endIndex": 1288,
             "endLine": 58,
             "startCol": 5,
-            "startIndex": 1267,
+            "startIndex": 1281,
             "startLine": 58,
           },
           "message": "The field 'in' must be present on this level.",
@@ -687,7 +687,7 @@ describe("Traverse files", () => {
         },
         Object {
           "codeFrame": "[90m43|   description:[39m
-      [90m44|     $ref: README.md[39m
+      [90m44|     $ref: inc/docs-description.md[39m
       [90m45|   [4m[31murl: googlecom[90m[24m[39m
       [90m46| components:[39m
       [90m47|   securitySchemes:[39m",
@@ -696,10 +696,10 @@ describe("Traverse files", () => {
           "fromRule": "oas3-schema/external-docs",
           "location": Object {
             "endCol": 16,
-            "endIndex": 922,
+            "endIndex": 936,
             "endLine": 45,
             "startCol": 3,
-            "startIndex": 908,
+            "startIndex": 922,
             "startLine": 45,
           },
           "message": "url must be a valid URL",

--- a/src/__tests__/validate.test.js
+++ b/src/__tests__/validate.test.js
@@ -348,7 +348,16 @@ describe("Traverse files", () => {
           "severity": 4,
           "target": "value",
           "value": Object {
-            "description": "some test",
+            "description": "# Test markdown file
+
+      This is a test markdown file.
+
+      Include it in your OpenAPI definition description like this: 
+
+
+          description:
+            $ref: path/to/file.md
+      ",
             "url": "googlecom",
           },
         },
@@ -712,7 +721,16 @@ describe("Traverse files", () => {
           "severity": 4,
           "target": "value",
           "value": Object {
-            "description": "some test",
+            "description": "# Test markdown file
+
+      This is a test markdown file.
+
+      Include it in your OpenAPI definition description like this: 
+
+
+          description:
+            $ref: path/to/file.md
+      ",
             "url": "googlecom",
           },
         },

--- a/src/__tests__/validate.test.js
+++ b/src/__tests__/validate.test.js
@@ -9,21 +9,21 @@ describe("Traverse files", () => {
       .toMatchInlineSnapshot(`
       Array [
         Object {
-          "codeFrame": "[90m56|   parameters:[39m
-      [90m57|     example:[39m
-      [90m58|       [4m[31mallOf[90m[24m:[39m
-      [90m59|         - name: bla[39m
-      [90m60|           in: query[39m",
+          "codeFrame": "[90m57|   parameters:[39m
+      [90m58|     example:[39m
+      [90m59|       [4m[31mallOf[90m[24m:[39m
+      [90m60|         - name: bla[39m
+      [90m61|           in: query[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "no-extra-fields",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1274,
-            "endLine": 58,
+            "endIndex": 1287,
+            "endLine": 59,
             "startCol": 7,
-            "startIndex": 1269,
-            "startLine": 58,
+            "startIndex": 1282,
+            "startLine": 59,
           },
           "message": "The field 'allOf' is not allowed in OpenAPIParameter. Use \\"x-\\" prefix or custom types to override this behavior.",
           "path": Array [
@@ -67,21 +67,21 @@ describe("Traverse files", () => {
           },
         },
         Object {
-          "codeFrame": "[90m55|       bearerFormat: JWT[39m
-      [90m56|   parameters:[39m
-      [90m57|     [4m[31mexample[90m[24m:[39m
-      [90m58|       allOf:[39m
-      [90m59|         - name: bla[39m",
+          "codeFrame": "[90m56|       bearerFormat: JWT[39m
+      [90m57|   parameters:[39m
+      [90m58|     [4m[31mexample[90m[24m:[39m
+      [90m59|       allOf:[39m
+      [90m60|         - name: bla[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "oas3-schema/parameter",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1261,
-            "endLine": 57,
+            "endIndex": 1274,
+            "endLine": 58,
             "startCol": 5,
-            "startIndex": 1254,
-            "startLine": 57,
+            "startIndex": 1267,
+            "startLine": 58,
           },
           "message": "The field 'name' must be present on this level.",
           "path": Array [
@@ -123,21 +123,21 @@ describe("Traverse files", () => {
           },
         },
         Object {
-          "codeFrame": "[90m55|       bearerFormat: JWT[39m
-      [90m56|   parameters:[39m
-      [90m57|     [4m[31mexample[90m[24m:[39m
-      [90m58|       allOf:[39m
-      [90m59|         - name: bla[39m",
+          "codeFrame": "[90m56|       bearerFormat: JWT[39m
+      [90m57|   parameters:[39m
+      [90m58|     [4m[31mexample[90m[24m:[39m
+      [90m59|       allOf:[39m
+      [90m60|         - name: bla[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "oas3-schema/parameter",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1261,
-            "endLine": 57,
+            "endIndex": 1274,
+            "endLine": 58,
             "startCol": 5,
-            "startIndex": 1254,
-            "startLine": 57,
+            "startIndex": 1267,
+            "startLine": 58,
           },
           "message": "The field 'in' must be present on this level.",
           "path": Array [
@@ -179,21 +179,21 @@ describe("Traverse files", () => {
           },
         },
         Object {
-          "codeFrame": "[90m56|   parameters:[39m
-      [90m57|     example:[39m
-      [90m58|       [4m[31mallOf[90m[24m:[39m
-      [90m59|         - name: bla[39m
-      [90m60|           in: query[39m",
+          "codeFrame": "[90m57|   parameters:[39m
+      [90m58|     example:[39m
+      [90m59|       [4m[31mallOf[90m[24m:[39m
+      [90m60|         - name: bla[39m
+      [90m61|           in: query[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "no-extra-fields",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1274,
-            "endLine": 58,
+            "endIndex": 1287,
+            "endLine": 59,
             "startCol": 7,
-            "startIndex": 1269,
-            "startLine": 58,
+            "startIndex": 1282,
+            "startLine": 59,
           },
           "message": "The field 'allOf' is not allowed in OpenAPIParameter. Use \\"x-\\" prefix or custom types to override this behavior.",
           "path": Array [
@@ -228,21 +228,21 @@ describe("Traverse files", () => {
           },
         },
         Object {
-          "codeFrame": "[90m55|       bearerFormat: JWT[39m
-      [90m56|   parameters:[39m
-      [90m57|     [4m[31mexample[90m[24m:[39m
-      [90m58|       allOf:[39m
-      [90m59|         - name: bla[39m",
+          "codeFrame": "[90m56|       bearerFormat: JWT[39m
+      [90m57|   parameters:[39m
+      [90m58|     [4m[31mexample[90m[24m:[39m
+      [90m59|       allOf:[39m
+      [90m60|         - name: bla[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "oas3-schema/parameter",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1261,
-            "endLine": 57,
+            "endIndex": 1274,
+            "endLine": 58,
             "startCol": 5,
-            "startIndex": 1254,
-            "startLine": 57,
+            "startIndex": 1267,
+            "startLine": 58,
           },
           "message": "The field 'name' must be present on this level.",
           "path": Array [
@@ -275,21 +275,21 @@ describe("Traverse files", () => {
           },
         },
         Object {
-          "codeFrame": "[90m55|       bearerFormat: JWT[39m
-      [90m56|   parameters:[39m
-      [90m57|     [4m[31mexample[90m[24m:[39m
-      [90m58|       allOf:[39m
-      [90m59|         - name: bla[39m",
+          "codeFrame": "[90m56|       bearerFormat: JWT[39m
+      [90m57|   parameters:[39m
+      [90m58|     [4m[31mexample[90m[24m:[39m
+      [90m59|       allOf:[39m
+      [90m60|         - name: bla[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "oas3-schema/parameter",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1261,
-            "endLine": 57,
+            "endIndex": 1274,
+            "endLine": 58,
             "startCol": 5,
-            "startIndex": 1254,
-            "startLine": 57,
+            "startIndex": 1267,
+            "startLine": 58,
           },
           "message": "The field 'in' must be present on this level.",
           "path": Array [
@@ -322,21 +322,21 @@ describe("Traverse files", () => {
           },
         },
         Object {
-          "codeFrame": "[90m42| externalDocs:[39m
-      [90m43|   description: asdasd[39m
-      [90m44|   [4m[31murl: googlecom[90m[24m[39m
-      [90m45| components:[39m
-      [90m46|   securitySchemes:[39m",
+          "codeFrame": "[90m43|   description:[39m
+      [90m44|     $ref: README.md[39m
+      [90m45|   [4m[31murl: googlecom[90m[24m[39m
+      [90m46| components:[39m
+      [90m47|   securitySchemes:[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "oas3-schema/external-docs",
           "location": Object {
             "endCol": 16,
-            "endIndex": 909,
-            "endLine": 44,
+            "endIndex": 922,
+            "endLine": 45,
             "startCol": 3,
-            "startIndex": 895,
-            "startLine": 44,
+            "startIndex": 908,
+            "startLine": 45,
           },
           "message": "url must be a valid URL",
           "path": Array [
@@ -348,7 +348,7 @@ describe("Traverse files", () => {
           "severity": 4,
           "target": "value",
           "value": Object {
-            "description": "asdasd",
+            "description": "some test",
             "url": "googlecom",
           },
         },
@@ -373,21 +373,21 @@ describe("Traverse files", () => {
       .toMatchInlineSnapshot(`
       Array [
         Object {
-          "codeFrame": "[90m56|   parameters:[39m
-      [90m57|     example:[39m
-      [90m58|       [4m[31mallOf[90m[24m:[39m
-      [90m59|         - name: bla[39m
-      [90m60|           in: query[39m",
+          "codeFrame": "[90m57|   parameters:[39m
+      [90m58|     example:[39m
+      [90m59|       [4m[31mallOf[90m[24m:[39m
+      [90m60|         - name: bla[39m
+      [90m61|           in: query[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "no-extra-fields",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1274,
-            "endLine": 58,
+            "endIndex": 1287,
+            "endLine": 59,
             "startCol": 7,
-            "startIndex": 1269,
-            "startLine": 58,
+            "startIndex": 1282,
+            "startLine": 59,
           },
           "message": "The field 'allOf' is not allowed in OpenAPIParameter. Use \\"x-\\" prefix or custom types to override this behavior.",
           "path": Array [
@@ -431,21 +431,21 @@ describe("Traverse files", () => {
           },
         },
         Object {
-          "codeFrame": "[90m55|       bearerFormat: JWT[39m
-      [90m56|   parameters:[39m
-      [90m57|     [4m[31mexample[90m[24m:[39m
-      [90m58|       allOf:[39m
-      [90m59|         - name: bla[39m",
+          "codeFrame": "[90m56|       bearerFormat: JWT[39m
+      [90m57|   parameters:[39m
+      [90m58|     [4m[31mexample[90m[24m:[39m
+      [90m59|       allOf:[39m
+      [90m60|         - name: bla[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "oas3-schema/parameter",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1261,
-            "endLine": 57,
+            "endIndex": 1274,
+            "endLine": 58,
             "startCol": 5,
-            "startIndex": 1254,
-            "startLine": 57,
+            "startIndex": 1267,
+            "startLine": 58,
           },
           "message": "The field 'name' must be present on this level.",
           "path": Array [
@@ -487,21 +487,21 @@ describe("Traverse files", () => {
           },
         },
         Object {
-          "codeFrame": "[90m55|       bearerFormat: JWT[39m
-      [90m56|   parameters:[39m
-      [90m57|     [4m[31mexample[90m[24m:[39m
-      [90m58|       allOf:[39m
-      [90m59|         - name: bla[39m",
+          "codeFrame": "[90m56|       bearerFormat: JWT[39m
+      [90m57|   parameters:[39m
+      [90m58|     [4m[31mexample[90m[24m:[39m
+      [90m59|       allOf:[39m
+      [90m60|         - name: bla[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "oas3-schema/parameter",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1261,
-            "endLine": 57,
+            "endIndex": 1274,
+            "endLine": 58,
             "startCol": 5,
-            "startIndex": 1254,
-            "startLine": 57,
+            "startIndex": 1267,
+            "startLine": 58,
           },
           "message": "The field 'in' must be present on this level.",
           "path": Array [
@@ -543,21 +543,21 @@ describe("Traverse files", () => {
           },
         },
         Object {
-          "codeFrame": "[90m56|   parameters:[39m
-      [90m57|     example:[39m
-      [90m58|       [4m[31mallOf[90m[24m:[39m
-      [90m59|         - name: bla[39m
-      [90m60|           in: query[39m",
+          "codeFrame": "[90m57|   parameters:[39m
+      [90m58|     example:[39m
+      [90m59|       [4m[31mallOf[90m[24m:[39m
+      [90m60|         - name: bla[39m
+      [90m61|           in: query[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "no-extra-fields",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1274,
-            "endLine": 58,
+            "endIndex": 1287,
+            "endLine": 59,
             "startCol": 7,
-            "startIndex": 1269,
-            "startLine": 58,
+            "startIndex": 1282,
+            "startLine": 59,
           },
           "message": "The field 'allOf' is not allowed in OpenAPIParameter. Use \\"x-\\" prefix or custom types to override this behavior.",
           "path": Array [
@@ -592,21 +592,21 @@ describe("Traverse files", () => {
           },
         },
         Object {
-          "codeFrame": "[90m55|       bearerFormat: JWT[39m
-      [90m56|   parameters:[39m
-      [90m57|     [4m[31mexample[90m[24m:[39m
-      [90m58|       allOf:[39m
-      [90m59|         - name: bla[39m",
+          "codeFrame": "[90m56|       bearerFormat: JWT[39m
+      [90m57|   parameters:[39m
+      [90m58|     [4m[31mexample[90m[24m:[39m
+      [90m59|       allOf:[39m
+      [90m60|         - name: bla[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "oas3-schema/parameter",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1261,
-            "endLine": 57,
+            "endIndex": 1274,
+            "endLine": 58,
             "startCol": 5,
-            "startIndex": 1254,
-            "startLine": 57,
+            "startIndex": 1267,
+            "startLine": 58,
           },
           "message": "The field 'name' must be present on this level.",
           "path": Array [
@@ -639,21 +639,21 @@ describe("Traverse files", () => {
           },
         },
         Object {
-          "codeFrame": "[90m55|       bearerFormat: JWT[39m
-      [90m56|   parameters:[39m
-      [90m57|     [4m[31mexample[90m[24m:[39m
-      [90m58|       allOf:[39m
-      [90m59|         - name: bla[39m",
+          "codeFrame": "[90m56|       bearerFormat: JWT[39m
+      [90m57|   parameters:[39m
+      [90m58|     [4m[31mexample[90m[24m:[39m
+      [90m59|       allOf:[39m
+      [90m60|         - name: bla[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "oas3-schema/parameter",
           "location": Object {
             "endCol": 12,
-            "endIndex": 1261,
-            "endLine": 57,
+            "endIndex": 1274,
+            "endLine": 58,
             "startCol": 5,
-            "startIndex": 1254,
-            "startLine": 57,
+            "startIndex": 1267,
+            "startLine": 58,
           },
           "message": "The field 'in' must be present on this level.",
           "path": Array [
@@ -686,21 +686,21 @@ describe("Traverse files", () => {
           },
         },
         Object {
-          "codeFrame": "[90m42| externalDocs:[39m
-      [90m43|   description: asdasd[39m
-      [90m44|   [4m[31murl: googlecom[90m[24m[39m
-      [90m45| components:[39m
-      [90m46|   securitySchemes:[39m",
+          "codeFrame": "[90m43|   description:[39m
+      [90m44|     $ref: README.md[39m
+      [90m45|   [4m[31murl: googlecom[90m[24m[39m
+      [90m46| components:[39m
+      [90m47|   securitySchemes:[39m",
           "enableCodeframe": true,
           "file": "definitions/syntetic/syntetic-1.yaml",
           "fromRule": "oas3-schema/external-docs",
           "location": Object {
             "endCol": 16,
-            "endIndex": 909,
-            "endLine": 44,
+            "endIndex": 922,
+            "endLine": 45,
             "startCol": 3,
-            "startIndex": 895,
-            "startLine": 44,
+            "startIndex": 908,
+            "startLine": 45,
           },
           "message": "url must be a valid URL",
           "path": Array [
@@ -712,7 +712,7 @@ describe("Traverse files", () => {
           "severity": 4,
           "target": "value",
           "value": Object {
-            "description": "asdasd",
+            "description": "some test",
             "url": "googlecom",
           },
         },

--- a/src/error/__tests__/default.test.js
+++ b/src/error/__tests__/default.test.js
@@ -205,7 +205,9 @@ describe("fromError", () => {
                 },
               },
               "externalDocs": Object {
-                "description": "asdasd",
+                "description": Object {
+                  "$ref": "README.md",
+                },
                 "url": "googlecom",
               },
               "info": Object {
@@ -322,7 +324,8 @@ describe("fromError", () => {
                     schema:
                       type: object
       externalDocs:
-        description: asdasd
+        description:
+          $ref: README.md
         url: googlecom
       components:
         securitySchemes:

--- a/src/error/__tests__/default.test.js
+++ b/src/error/__tests__/default.test.js
@@ -206,7 +206,7 @@ describe("fromError", () => {
               },
               "externalDocs": Object {
                 "description": Object {
-                  "$ref": "README.md",
+                  "$ref": "inc/docs-description.md",
                 },
                 "url": "googlecom",
               },
@@ -325,7 +325,7 @@ describe("fromError", () => {
                       type: object
       externalDocs:
         description:
-          $ref: README.md
+          $ref: inc/docs-description.md
         url: googlecom
       components:
         securitySchemes:

--- a/src/scalarsResolver.js
+++ b/src/scalarsResolver.js
@@ -1,0 +1,24 @@
+import path from 'path';
+import fs from 'fs';
+import createError from './error';
+
+
+export default function resolveScalars(resolvedNode, definition, ctx) {
+  Object.keys(definition.properties)
+    .filter((k) => resolvedNode[k])
+    .filter((k) => typeof resolvedNode[k] === 'object')
+    .filter((k) => definition.resolvableScalars && definition.resolvableScalars.indexOf(k) !== -1)
+    .filter((k) => resolvedNode[k].$ref)
+    .forEach((k) => {
+      const resolvedFilePath = path.resolve(path.dirname(ctx.filePath), resolvedNode[k].$ref);
+      if (fs.existsSync(resolvedFilePath)) {
+        resolvedNode[k] = fs.readFileSync(resolvedFilePath, 'utf-8');
+      } else {
+        ctx.path.push(k);
+        ctx.path.push('$ref');
+        ctx.result.push(createError('Reference does not exist.', resolvedNode, ctx, { fromRule: 'resolve-scalars' }));
+        ctx.path.pop();
+        ctx.path.pop();
+      }
+    });
+}

--- a/src/traverse.js
+++ b/src/traverse.js
@@ -6,6 +6,7 @@ import path from 'path';
 import resolveNode from './resolver';
 import resolveDefinition from './resolveDefinition';
 import resolveType from './resolveType';
+import resolveScalars from './scalarsResolver';
 
 import { fromError, createErrorFlat } from './error/default';
 
@@ -96,12 +97,12 @@ const nestedIncludes = (c, s) => {
   return res;
 };
 
+
 function traverseNode(node, definition, ctx, visited = []) {
   if (!node || !definition) return [];
 
   const nodeContext = onNodeEnter(node, ctx);
   const isRecursive = nestedIncludes(ctx.path, visited);
-
   const errors = [];
   const currentPath = `${path.relative(process.cwd(), ctx.filePath)}::${ctx.path.join('/')}`;
 
@@ -109,7 +110,7 @@ function traverseNode(node, definition, ctx, visited = []) {
   localVisited.push(currentPath);
 
   const resolvedDefinition = resolveDefinition(definition, ctx, nodeContext.resolvedNode);
-
+  resolveScalars(nodeContext.resolvedNode, definition, ctx);
   if (Array.isArray(nodeContext.resolvedNode)) {
     nodeContext.resolvedNode.forEach((nodeChild, i) => {
       ctx.path.push(i);

--- a/src/types/OpenAPIExample.js
+++ b/src/types/OpenAPIExample.js
@@ -7,6 +7,9 @@ export const OpenAPIExample = {
     description: null,
     summary: null,
   },
+  resolvableScalars: [
+    'description',
+  ],
 };
 
 export default OpenAPIExample;

--- a/src/types/OpenAPIExternalDocumentation.js
+++ b/src/types/OpenAPIExternalDocumentation.js
@@ -5,6 +5,9 @@ const OpenAPIExternalDocumentation = {
     description: null,
     url: null,
   },
+  resolvableScalars: [
+    'description',
+  ],
 };
 
 export default OpenAPIExternalDocumentation;

--- a/src/types/OpenAPIHeader.js
+++ b/src/types/OpenAPIHeader.js
@@ -18,6 +18,9 @@ export const OpenAPIHeader = {
     content: OpenAPIMediaTypeObject,
     examples: OpenAPIExampleMap,
   },
+  resolvableScalars: [
+    'description',
+  ],
 };
 
 export default OpenAPIHeader;

--- a/src/types/OpenAPIInfo.js
+++ b/src/types/OpenAPIInfo.js
@@ -13,6 +13,9 @@ export const OpenAPIInfo = {
     license: OpenAPILicense,
     contact: OpenAPIContact,
   },
+  resolvableScalars: [
+    'description',
+  ],
 };
 
 export default OpenAPIInfo;

--- a/src/types/OpenAPILink.js
+++ b/src/types/OpenAPILink.js
@@ -11,6 +11,9 @@ export const OpenAPILink = {
     requestBody: null,
     server: OpenAPIServer,
   },
+  resolvableScalars: [
+    'description',
+  ],
 };
 
 export default OpenAPILink;

--- a/src/types/OpenAPIOperation.js
+++ b/src/types/OpenAPIOperation.js
@@ -26,4 +26,7 @@ export default {
     // security() {},
     servers: OpenAPIServer,
   },
+  resolvableScalars: [
+    'description',
+  ],
 };

--- a/src/types/OpenAPIParameter.js
+++ b/src/types/OpenAPIParameter.js
@@ -20,6 +20,9 @@ export const OpenAPIParameter = {
     content: OpenAPIMediaTypeObject,
     examples: OpenAPIExampleMap,
   },
+  resolvableScalars: [
+    'description',
+  ],
 };
 
 export default OpenAPIParameter;

--- a/src/types/OpenAPIPath.js
+++ b/src/types/OpenAPIPath.js
@@ -20,6 +20,9 @@ export const OpenAPIPathItem = {
     trace: OpenAPIOperation,
     servers: OpenAPIServer,
   },
+  resolvableScalars: [
+    'description',
+  ],
 };
 
 

--- a/src/types/OpenAPIRequestBody.js
+++ b/src/types/OpenAPIRequestBody.js
@@ -8,6 +8,9 @@ export const OpenAPIRequestBody = {
     required: null,
     content: OpenAPIMediaTypeObject,
   },
+  resolvableScalars: [
+    'description',
+  ],
 };
 
 export default OpenAPIRequestBody;

--- a/src/types/OpenAPIResponse.js
+++ b/src/types/OpenAPIResponse.js
@@ -12,6 +12,9 @@ export const OpenAPIResponse = {
     headers: OpenAPIHeaderMap,
     links: OpenAPILinkMap,
   },
+  resolvableScalars: [
+    'description',
+  ],
 };
 
 export default OpenAPIResponse;

--- a/src/types/OpenAPISchema.js
+++ b/src/types/OpenAPISchema.js
@@ -57,6 +57,9 @@ const OpenAPISchemaObject = {
     example: null,
     default: null,
   },
+  resolvableScalars: [
+    'description',
+  ],
 };
 
 export default OpenAPISchemaObject;

--- a/src/types/OpenAPISecuritySchema.js
+++ b/src/types/OpenAPISecuritySchema.js
@@ -12,4 +12,7 @@ export default {
     openIdConnectUrl: null,
     flows: OpenAPIFlows,
   },
+  resolvableScalars: [
+    'description',
+  ],
 };

--- a/src/types/OpenAPIServer.js
+++ b/src/types/OpenAPIServer.js
@@ -10,6 +10,9 @@ const OpenAPIServer = {
       return OpenAPIServerVariableMap;
     },
   },
+  resolvableScalars: [
+    'description',
+  ],
 };
 
 export default OpenAPIServer;

--- a/src/types/OpenAPIServerVariable.js
+++ b/src/types/OpenAPIServerVariable.js
@@ -6,4 +6,7 @@ export default {
     description: null,
     enum: null,
   },
+  resolvableScalars: [
+    'description',
+  ],
 };

--- a/src/types/OpenAPITag.js
+++ b/src/types/OpenAPITag.js
@@ -8,4 +8,7 @@ export default {
     description: null,
     externalDocs: OpenAPIExternalDocumentation,
   },
+  resolvableScalars: [
+    'description',
+  ],
 };


### PR DESCRIPTION
For now, only in 'description' field. However, this can be updated by adding 'resolvableScalars' field to the type definition for which the user wants to allow such scalars. 'resolvableScalars' is an array which must contain a list of scalars of the type for which $refs are allowed.

Now, we allow only file system references. However, it might make sense to allow also document-based $refs, like 'some/other/file.yaml#/some/node', although it will increase complexity of this module significantly.