### PR TITLE
Rename Open API to proper OpenAPI without space

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -88,10 +88,10 @@ Below, you can find the table of available sub-rules you can update:
 | Sub-rule name | OpenAPI Object it corresponds to|
 |---|---|
 | root | [OpenAPI Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#oasObject) |
-| info | [Open API Info Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#infoObject) |
-| contact | [Open API Contact Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#contactObject) |
-| discriminator | [Open API Discriminator Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#discriminatorObject) |
-| encoding | [Open API Encoding Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#encodingObject) |
+| info | [OpenAPI Info Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#infoObject) |
+| contact | [OpenAPI Contact Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#contactObject) |
+| discriminator | [OpenAPI Discriminator Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#discriminatorObject) |
+| encoding | [OpenAPI Encoding Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#encodingObject) |
 | example | [OpenAPI Example Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#exampleObject) |
 | external-docs | [OpenAPI External Documentation Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#externalDocumentationObject) |
 | header | [OpenAPI Header Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#headerObject) |
@@ -105,10 +105,10 @@ Below, you can find the table of available sub-rules you can update:
 | response | [OpenAPI Response Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#responseObject) |
 | schema | [OpenAPI Schema Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#schemaObject) |
 | secuirty-schema | [OpenAPI Security Scheme Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#securitySchemeObject)|
-| auth-code-flow | [Open API Flow Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#oauthFlowObject)|
-| client-creds-flow | [Open API Flow Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#oauthFlowObject)|
-| implicit-flow | [Open API Flow Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#oauthFlowObject)|
-| password-flow | [Open API Flow Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#oauthFlowObject)|
+| auth-code-flow | [OpenAPI Flow Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#oauthFlowObject)|
+| client-creds-flow | [OpenAPI Flow Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#oauthFlowObject)|
+| implicit-flow | [OpenAPI Flow Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#oauthFlowObject)|
+| password-flow | [OpenAPI Flow Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#oauthFlowObject)|
 | server | [OpenAPI Server Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#serverObject) |
 | server-variable | [OpenAPI Server Variable Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#serverVariableObject) |
 | tag | [OpenAPI Tag Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#tagObject) |

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -109,7 +109,7 @@ const cli = () => {
 
   program
     .command('validate [entryPoints...]')
-    .description('Validate given Open API 3 definition file.')
+    .description('Validate given OpenAPI 3 definition file.')
     .option('--short', 'Reduce output to required minimun')
     .option('--no-frame', 'Print no codeframes with errors.')
     .option('--config <path>', 'Specify custom yaml or json config')

--- a/src/visitors/rules/structural/validateAuthorizationCodeOpenAPIFlow.js
+++ b/src/visitors/rules/structural/validateAuthorizationCodeOpenAPIFlow.js
@@ -16,14 +16,14 @@ class ValidateAuthorizationCodeOpenAPIFlow {
         return null;
       },
       refreshUrl(node, ctx) {
-        if (node.refreshUrl && typeof node.refreshUrl !== 'string') return ctx.createError('The refreshUrl must be a string in the Open API Flow Object', 'value');
+        if (node.refreshUrl && typeof node.refreshUrl !== 'string') return ctx.createError('The refreshUrl must be a string in the OpenAPI Flow Object', 'value');
         return null;
       },
       scopes(node, ctx) {
         const wrongFormatMap = Object.keys(node.scopes)
           .filter((scope) => typeof scope !== 'string' || typeof node.scopes[scope] !== 'string')
           .length > 0;
-        if (wrongFormatMap) return ctx.createError('The scopes field must be a Map[string, string] in the Open API Flow Object', 'value');
+        if (wrongFormatMap) return ctx.createError('The scopes field must be a Map[string, string] in the OpenAPI Flow Object', 'value');
         return null;
       },
     };

--- a/src/visitors/rules/structural/validateClientCredentialsOpenAPIFlow.js
+++ b/src/visitors/rules/structural/validateClientCredentialsOpenAPIFlow.js
@@ -18,7 +18,7 @@ class ValidateClientCredentialsOpenAPIFlow {
         const wrongFormatMap = Object.keys(node.scopes)
           .filter((scope) => typeof scope !== 'string' || typeof node.scopes[scope] !== 'string')
           .length > 0;
-        if (wrongFormatMap) return ctx.createError('The scopes field must be a Map[string, string] in the Open API Flow Object', 'value');
+        if (wrongFormatMap) return ctx.createError('The scopes field must be a Map[string, string] in the OpenAPI Flow Object', 'value');
         return null;
       },
     };

--- a/src/visitors/rules/structural/validateImplicitOpenAPIFlow.js
+++ b/src/visitors/rules/structural/validateImplicitOpenAPIFlow.js
@@ -19,7 +19,7 @@ class ValidateImplicitOpenAPIFlow {
         const wrongFormatMap = Object.keys(node.scopes)
           .filter((scope) => typeof scope !== 'string' || typeof node.scopes[scope] !== 'string')
           .length > 0;
-        if (wrongFormatMap) return ctx.createError('The scopes field must be a Map[string, string] in the Open API Flow Object', 'value');
+        if (wrongFormatMap) return ctx.createError('The scopes field must be a Map[string, string] in the OpenAPI Flow Object', 'value');
         return null;
       },
     };

--- a/src/visitors/rules/structural/validateOpenAPIOperation.js
+++ b/src/visitors/rules/structural/validateOpenAPIOperation.js
@@ -17,7 +17,7 @@ class ValidateOpenAPIOperation {
         for (let i = 0; i < node.tags.length; i++) {
           if (typeof node.tags[i] !== 'string') {
             ctx.path.push(i);
-            errors.push(ctx.createError('Items of the tags array must be strings in the Open API Operation object.', 'value'));
+            errors.push(ctx.createError('Items of the tags array must be strings in the OpenAPI Operation object.', 'value'));
             ctx.path.pop();
           }
         }

--- a/src/visitors/rules/structural/validatePasswordOpenAPIFlow.js
+++ b/src/visitors/rules/structural/validatePasswordOpenAPIFlow.js
@@ -18,7 +18,7 @@ class ValidatePasswordOpenAPIFlow {
         const wrongFormatMap = Object.keys(node.scopes)
           .filter((scope) => typeof scope !== 'string' || typeof node.scopes[scope] !== 'string')
           .length > 0;
-        if (wrongFormatMap) return ctx.createError('The scopes field must be a Map[string, string] in the Open API Flow Object', 'value');
+        if (wrongFormatMap) return ctx.createError('The scopes field must be a Map[string, string] in the OpenAPI Flow Object', 'value');
         return null;
       },
     };


### PR DESCRIPTION
The proper name is OpenAPI (not Open API).