### PR TITLE
feat: support aliases in entryPoints argument

### DIFF
--- a/definitions/.redocly.yml
+++ b/definitions/.redocly.yml
@@ -1,31 +1,33 @@
-typeExtension: typeExtension.js
-# customRules: customRules.js
-transformers: customRules.js
-codeframes: on
-rules:
-  bundler: off
-  debug-info: off
+apiDefinitions:
+  simpleDefinition: ./syntetic/syntetic.yaml
+  anotherWithError: ./syntetic/syntetic-2.yaml
 
-  parameterPartial: warning
-  parameterWithAllOf: warning
+lint:
+  codeframes: on
+  rules:
+    bundler: off
+    debug-info: off
 
-  oas3-schema/parameter: off
-  oas3-schema/external-docs:
-    url: off
+    parameterPartial: warning
+    parameterWithAllOf: warning
+
+    oas3-schema/parameter: off
+    oas3-schema/external-docs:
+      url: off
 
 
-  path-param-exists: on
-  operation-2xx-response: on
-  unique-parameter-names: on
-  no-unused-schemas: on
-  operation-operationId-unique: on
-  path-declarations-must-exist: on
+    path-param-exists: on
+    operation-2xx-response: on
+    unique-parameter-names: on
+    no-unused-schemas: on
+    operation-operationId-unique: on
+    path-declarations-must-exist: on
 
-  api-servers: on
-  license-url: on
-  no-extra-fields: on
-  operation-description: on
-  operation-operationId: on
-  operation-tags: off
-  provide-contact: on
-  servers-no-trailing-slash: on
+    api-servers: on
+    license-url: on
+    no-extra-fields: on
+    operation-description: on
+    operation-operationId: on
+    operation-tags: off
+    provide-contact: on
+    servers-no-trailing-slash: on

--- a/definitions/syntetic/syntetic-2.yaml
+++ b/definitions/syntetic/syntetic-2.yaml
@@ -1,0 +1,88 @@
+openapi: 3.0.2
+info:
+  x-redocly-overlay:
+    path: overlay-info.yaml
+  title: Example OpenAPI 3 definition. Valid.
+  version: 1.0
+  contact:
+    name: Ivan Goncharov
+    email: ivan@redoc.ly
+  license:
+    name: example
+    url: example.org
+
+servers:
+  - url: 'http://example.org'
+
+paths:
+  user:
+    parameters:
+      - $ref: '#/components/parameters/example'
+    get:
+      operationId: userGet
+      description: Get user
+      responses:
+        '200':
+          description: example description
+          content:
+            application/json:
+              schema:
+                type: object
+  project:
+    get:
+      operationId: projectGet
+      description: Get project
+      responses:
+        '200':
+          description: example description
+          content:
+            application/json:
+              schema:
+                type: object
+  '/user/{id}':
+    get:
+      parameters:
+        - in: path
+          name: test
+          description: User id
+          required: true
+          schema:
+            type: string
+      operationId: withPathParam
+      description: Get user by id
+      responses:
+        '200':
+          description: example description
+          content:
+            application/json:
+              schema:
+                type: object
+externalDocs:
+  description:
+    $ref: inc/docs-description.md
+  url: googlecom
+components:
+  securitySchemes:
+    JWT:
+      description: >
+        You can create a JSON Web Token (JWT) via our [JWT Session
+        resource](https://rebilly.github.io/RebillyUserAPI/#tag/JWT-Session/paths/~1signin/post).
+
+        Usage format: `Bearer <JWT>`
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  parameters:
+    example:
+      name: bla
+      in: query
+      required: false
+      schema:
+        type: string
+      description: blo
+    genericExample:
+      name: example
+      in: query
+      required: true
+      schema:
+        type: string

--- a/definitions/syntetic/syntetic.yaml
+++ b/definitions/syntetic/syntetic.yaml
@@ -1,0 +1,88 @@
+openapi: 3.0.2
+info:
+  x-redocly-overlay:
+    path: overlay-info.yaml
+  title: Example OpenAPI 3 definition. Valid.
+  version: 1.0
+  contact:
+    name: Ivan Goncharov
+    email: ivan@redoc.ly
+  license:
+    name: example
+    url: example.org
+
+servers:
+  - url: 'http://example.org'
+
+paths:
+  user:
+    parameters:
+      - $ref: '#/components/parameters/example'
+    get:
+      operationId: userGet
+      description: Get user
+      responses:
+        '200':
+          description: example description
+          content:
+            application/json:
+              schema:
+                type: object
+  project:
+    get:
+      operationId: projectGet
+      description: Get project
+      responses:
+        '200':
+          description: example description
+          content:
+            application/json:
+              schema:
+                type: object
+  '/user/{id}/{test}':
+    get:
+      parameters:
+        - in: path
+          name: test
+          description: User id
+          required: true
+          schema:
+            type: string
+      operationId: withPathParam
+      description: Get user by id
+      responses:
+        '200':
+          description: example description
+          content:
+            application/json:
+              schema:
+                type: object
+externalDocs:
+  description:
+    $ref: inc/docs-description.md
+  url: googlecom
+components:
+  securitySchemes:
+    JWT:
+      description: >
+        You can create a JSON Web Token (JWT) via our [JWT Session
+        resource](https://rebilly.github.io/RebillyUserAPI/#tag/JWT-Session/paths/~1signin/post).
+
+        Usage format: `Bearer <JWT>`
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  parameters:
+    example:
+      name: bla
+      in: query
+      required: false
+      schema:
+        type: string
+      description: blo
+    genericExample:
+      name: example
+      in: query
+      required: true
+      schema:
+        type: string

--- a/src/config.js
+++ b/src/config.js
@@ -86,9 +86,7 @@ export function getFallbackEntryPointsOrExit(argsEntrypoints, config = getConfig
   ) {
     res = Object.values(config.apiDefinitions);
   } else if (argsEntrypoints && argsEntrypoints.length && config.apiDefinitions) {
-    for (let i = 0; i < argsEntrypoints.length; i++) {
-      res[i] = config.apiDefinitions[res[i]] || res[i];
-    }
+    res = res.map(aliasOrPath => config.apiDefinitions[aliasOrPath] || aliasOrPath);
   }
 
   if (!res || !res.length) {

--- a/src/config.js
+++ b/src/config.js
@@ -85,6 +85,11 @@ export function getFallbackEntryPointsOrExit(argsEntrypoints, config = getConfig
     && Object.keys(config.apiDefinitions).length > 0
   ) {
     res = Object.values(config.apiDefinitions);
+  } else if (argsEntrypoints && argsEntrypoints.length && config.apiDefinitions) {
+    const aliases = Object.keys(config.apiDefinitions);
+    for (let i = 0; i < argsEntrypoints.length; i++) {
+      res[i] = aliases.indexOf(argsEntrypoints[i]) !== -1 ? config.apiDefinitions[res[i]] : res[i];
+    }
   }
 
   if (!res || !res.length) {

--- a/src/config.js
+++ b/src/config.js
@@ -86,9 +86,8 @@ export function getFallbackEntryPointsOrExit(argsEntrypoints, config = getConfig
   ) {
     res = Object.values(config.apiDefinitions);
   } else if (argsEntrypoints && argsEntrypoints.length && config.apiDefinitions) {
-    const aliases = Object.keys(config.apiDefinitions);
     for (let i = 0; i < argsEntrypoints.length; i++) {
-      res[i] = aliases.indexOf(argsEntrypoints[i]) !== -1 ? config.apiDefinitions[res[i]] : res[i];
+      res[i] = config.apiDefinitions[res[i]] || res[i];
     }
   }
 


### PR DESCRIPTION
Allow to call `openapi` command in following ways:

```bash
openapi { validate | bundle } alias anotherAlias ./some_path/definition.yaml  # will lookup for aliases resolutions in the apiDefinitions field of config and then validate both aliased files and direct file path
```

## Important note
For now collision is possible, e.g.:
```yaml
apiDefinitions:
  public: ./definition.yaml
  "private.yaml": ./another/file.yaml
```
Will cause `openapi validate private.yaml` to lookup definition in the `./another/file.yaml` even if `private.yaml` exists in current dir.