### PR TITLE
fix: use fully qualified url for XHR instead of filePath

### DIFF
--- a/src/resolver.js
+++ b/src/resolver.js
@@ -74,7 +74,7 @@ function resolve(link, ctx, visited = []) {
     } else if (isFullyQualifiedUrl(resolvedFilePath)) {
       try {
         const xhr = new XMLHttpRequest();
-        xhr.open('GET', filePath, false);
+        xhr.open('GET', resolvedFilePath, false);
         xhr.send();
 
         if (xhr.status !== 200) {


### PR DESCRIPTION
This was causing request to be sent with a filename instead of the URL it should go

Fixes #105 