### PR TITLE
feat: no-scalar-refs rule

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -17,6 +17,9 @@ License, if provided within the `info` section, must provide the `url` field.
 ### no-unused-schemas
 Unused schemas defined in `components` may indicate a mistake. This rule checks for that scenario.
 
+### no-scalar-ref
+Scalar values should not be linked via `$ref`s.
+
 ### operation-2xx-response
 When designing an API it's usually expected to do something successfully, although it might fail. So, this rule validates, that there is at least one response in the operation with a 2xx status code.
 

--- a/src/.redocly.yaml
+++ b/src/.redocly.yaml
@@ -7,6 +7,7 @@ lint:
 
     no-extra-fields: warning
     no-$ref-siblings: warning
+    no-scalar-ref: warning
 
     suggest-possible-refs: on
     oas3-schema: on

--- a/src/visitors/rules/semantic/no-scalar-ref.js
+++ b/src/visitors/rules/semantic/no-scalar-ref.js
@@ -1,0 +1,27 @@
+class NoScalarRef {
+  static get rule() {
+    return 'no-scalar-ref';
+  }
+
+  any() {
+    return {
+      onExit: (node, definition, ctx) => {
+        const errors = [];
+        for (const property of Object.keys(definition.properties)) {
+          if (definition.properties[property] === null && Object.keys(node[property] || {}).includes('$ref')) {
+            ctx.path.push(property);
+            ctx.path.push('$ref');
+            errors.push(ctx.createError(
+              '$ref reference is used for a scalar value.', 'key',
+            ));
+            ctx.path.pop();
+            ctx.path.pop();
+          }
+        }
+        return errors;
+      },
+    };
+  }
+}
+
+module.exports = NoScalarRef;


### PR DESCRIPTION
Adds `no-scalar-ref` rule for both OAS 2 & OAS 3.

[Corresponding issue](https://trello.com/c/Gawa8rPH/759-warning-in-openapi-cli-if-scalar-has-refs)