### PR TITLE
feat: handle no openapi case in openapi

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -102,8 +102,7 @@ export function detectOpenAPI(root: any): OasVersion {
   }
 
   if (!(root.openapi || root.swagger)) {
-    process.stderr.write('❗️❗️❗️ This doesn’t look like an OpenAPI document.\n');
-    process.exit(1);
+    throw new Error('This doesn’t look like an OpenAPI document.\n');
   }
 
   if (root.openapi && root.openapi.startsWith('3.0')) {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -101,6 +101,11 @@ export function detectOpenAPI(root: any): OasVersion {
     throw new Error(`Document must be JSON object, got ${typeof root}`);
   }
 
+  if (!(root.openapi || root.swagger)) {
+    process.stderr.write('❗️❗️❗️ This doesn’t look like an OpenAPI document.\n');
+    process.exit(1);
+  }
+
   if (root.openapi && root.openapi.startsWith('3.0')) {
     return OasVersion.Version3_0;
   }


### PR DESCRIPTION
I think we can safely exit(1) right when we know that document is not openapi, so that we don't need additional handling logic, but might be wrong here.