### PR TITLE
chore: fix help message with correct login command

### DIFF
--- a/src/redocly/index.ts
+++ b/src/redocly/index.ts
@@ -48,7 +48,7 @@ export class RedoclyClient {
       process.stderr.write(
         `${yellow(
           'Warning:',
-        )} invalid Redoc.ly access token. Use "npx @redocly/openapi-cli registry:login" to provide your access token\n`,
+        )} invalid Redoc.ly access token. Use "npx @redocly/openapi-cli login" to provide your access token\n`,
       );
       return undefined;
     }


### PR DESCRIPTION
Fixes a minor bug where the help message displays references the `registry:login` command instead of the `login` command. 