### PR TITLE
Credit OAS-kit for original Speccy/Spectral ruleset

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ Unlike other OpenAPI linters, `@redocly/openapi-cli` defines the possible type t
 
 ## Credits
 
-Thanks to [graphql-js](https://github.com/graphql/graphql-js) and [eslint](https://github.com/eslint/eslint) for inspiration of the definition traversal approach and to [Swagger](https://github.com/swagger-api/swagger-editor), [Spectral](https://github.com/stoplightio/spectral), and [Speccy](https://github.com/wework/speccy) for inspiring the ruleset.
+Thanks to [graphql-js](https://github.com/graphql/graphql-js) and [eslint](https://github.com/eslint/eslint) for inspiration of the definition traversal approach and to [Swagger](https://github.com/swagger-api/swagger-editor), [Spectral](https://github.com/stoplightio/spectral), and [OAS-Kit](https://github.com/Mermade/oas-kit) for inspiring the ruleset.


### PR DESCRIPTION
Speccy (was, it is now unmaintained) a thin wrapper around OAS-Kit's `oas-linter`. These rules then went on to inspire the original set in Spectral.