### PR TITLE
feat: use all parts of pointer to generate uniq component name if needed

### DIFF
--- a/src/__tests__/__snapshots__/bundle.test.ts.snap
+++ b/src/__tests__/__snapshots__/bundle.test.ts.snap
@@ -24,12 +24,27 @@ components:
       name: param_a
       schema:
         $ref: '#/components/schemas/schema-a'
+      examples:
+        first:
+          $ref: '#/components/examples/param-a-first'
+        second:
+          $ref: '#/components/examples/second'
     path-param:
       name: path_param
+      examples:
+        first:
+          $ref: '#/components/examples/first'
     param-c:
       name: param_c
     param-b:
       name: param_b
+  examples:
+    first:
+      value: b1
+    param-a-first:
+      value: a1
+    second:
+      value: a2
   schemas:
     schema-a:
       type: string

--- a/src/__tests__/fixtures/refs/examples.yaml
+++ b/src/__tests__/fixtures/refs/examples.yaml
@@ -1,0 +1,8 @@
+param-a:
+  first:
+    value: a1
+  second:
+    value: a2
+path-param:
+  first:
+    value: b1

--- a/src/__tests__/fixtures/refs/openapi-with-external-refs.yaml
+++ b/src/__tests__/fixtures/refs/openapi-with-external-refs.yaml
@@ -21,5 +21,13 @@ components:
       name: param_a
       schema:
         $ref: ./schema-a.yaml
+      examples:
+        first:
+          $ref: ./examples.yaml#/param-a/first
+        second:
+          $ref: ./examples.yaml#/param-a/second
     path-param:
       name: path_param
+      examples:
+        first:
+          $ref: ./examples.yaml#/path-param/first


### PR DESCRIPTION
Currently only the last part of the pointer (e.g. #/foo/bar -> bar) is
used for naming the component. If it's already taken, the base name of
the file reference is prepended. If it's still not unique, a sequence
number is appended to the name and warning is printed (`Two schemas are
referenced with the same name but different content.`).

The warning message is quite misleading and unnecessary because it's not
the user's fault that we used only the last part of the pointer to
generate unique component name.

To show some real-world example, let's consider file `examples.yml` with
examples for multiple types where each type may have multiple variants:

- #/Car/basic
- #/Car/electric
- #/Bike/basic
- #/Scooter/basic

The function `getComponentName()` will generate: basic, electric,
examples_basic, examples_basic-2, and warn about conflicting name of the
last. That's quite irritating, especially since the user cannot hide
these messages.

This commit solves this problem by changing the name generation
algorithm in `getComponentName()` to be gradually adding all the
components of the pointer from left to right before prepending the base
of the file reference and appending a serial.

Now for the example above the function will generate: basic, electric,
bike-basic, scooter-basic.