### PR TITLE
fix: remove extra blank line printed by printLintTotals()

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -411,7 +411,7 @@ function printLintTotals(totals: Totals, definitionsCount: number) {
           totals.warnings > 0
             ? ` and ${totals.warnings} ${pluralize('warning', totals.warnings)}`
             : ''
-        }.\n${ignored}\n`,
+        }.\n${ignored}`,
       ),
     );
   } else if (totals.warnings > 0) {
@@ -419,7 +419,7 @@ function printLintTotals(totals: Totals, definitionsCount: number) {
       green(`Woohoo! Your OpenAPI ${pluralize('definition is', definitionsCount)} valid. 🎉\n`),
     );
     process.stderr.write(
-      yellow(`You have ${totals.warnings} ${pluralize('warning', totals.warnings)}.\n${ignored}\n`),
+      yellow(`You have ${totals.warnings} ${pluralize('warning', totals.warnings)}.\n${ignored}`),
     );
   } else {
     process.stderr.write(
@@ -427,7 +427,7 @@ function printLintTotals(totals: Totals, definitionsCount: number) {
         `Woohoo! Your OpenAPI ${pluralize(
           'definition is',
           definitionsCount,
-        )} valid. 🎉\n${ignored}\n`,
+        )} valid. 🎉\n${ignored}`,
       ),
     );
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -401,7 +401,7 @@ function handleError(e: Error, ref: string) {
 
 function printLintTotals(totals: Totals, definitionsCount: number) {
   const ignored = totals.ignored
-    ? yellow(`${totals.ignored} ${pluralize('problem is', totals.ignored)} explicitly ignored.\n`)
+    ? yellow(`${totals.ignored} ${pluralize('problem is', totals.ignored)} explicitly ignored.\n\n`)
     : '';
 
   if (totals.errors > 0) {


### PR DESCRIPTION
`ignored` already ends with a newline, so when no rules are ignored, two
empty lines are printed after the green validation result message.
It's quite irritating when you run multiple linters in sequence...