### PR TITLE
fix: crash with backrefs

### DIFF
--- a/src/__tests__/fixtures/resolve/openapi-with-back.yaml
+++ b/src/__tests__/fixtures/resolve/openapi-with-back.yaml
@@ -1,0 +1,13 @@
+openapi: "3.0.1"
+info:
+  title: Open API
+  description: Open API
+  version: v0
+  contact:
+    email: some@body.com
+components:
+  schemas:
+    TypeA:
+      $ref: ./schemas/type-a.yaml#/
+    TypeB:
+      $ref: ./schemas/type-b.yaml#/

--- a/src/__tests__/fixtures/resolve/schemas/type-a.yaml
+++ b/src/__tests__/fixtures/resolve/schemas/type-a.yaml
@@ -1,0 +1,10 @@
+allOf:
+  - type: object
+    required:
+      - name
+      - integration_type
+    properties:
+      integration_type:
+        $ref: "../openapi-with-back.yaml#/components/schemas/TypeB"
+      name:
+        type: string

--- a/src/__tests__/fixtures/resolve/schemas/type-b.yaml
+++ b/src/__tests__/fixtures/resolve/schemas/type-b.yaml
@@ -1,0 +1,6 @@
+type: string
+enum:
+  - webhook
+  - api_key
+  - sftp
+  - netsuite

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -302,7 +302,7 @@ export async function resolveDocument(opts: {
       let targetDoc: Document;
       try {
         targetDoc = isRemote
-          ? ((await externalRefResolver.resolveDocument(rootNodeDocAbsoluteRef, uri!)) as Document)
+          ? ((await externalRefResolver.resolveDocument(document.source.absoluteRef, uri!)) as Document)
           : document;
       } catch (error) {
         const resolvedRef = {


### PR DESCRIPTION
Closes #184 

The problem was that when we went down the ref, we don't change the absolute path in rootNodeDocAbsoluteRef and that results in failures to resolve next $refs.