### PR TITLE
fix: use platfrom specific separator

### DIFF
--- a/src/ref-utils.ts
+++ b/src/ref-utils.ts
@@ -1,3 +1,5 @@
+import { sep as platformDependentSeparator } from 'path';
+
 import { Source } from './resolve';
 import { OasRef } from './typings/openapi';
 
@@ -59,7 +61,7 @@ export function pointerBaseName(pointer: string) {
 }
 
 export function refBaseName(ref: string) {
-  const parts = ref.split('/');
+  const parts = ref.split(platformDependentSeparator);
   return parts[parts.length - 1].split('.')[0];
 }
 


### PR DESCRIPTION
The problem was that for Windows machines `openapi-cli` tried to use `/` instead of `\` for a file path splitting. Because of that, when bundling our tool used full paths as components names which lead to such cases as:

```
responses:
  '200':
    description: Success
    content:
      application/json:
        schema:
          $ref: >-
            #/components/schemas/C:\repos\redocly-test\openapi\components\schemas\User
        example:
          username: user1
          email: user@example.com
```
Although that is a technically valid definition, it is not what we want to get.

Also, I was able to run the `openapi-cli` development process on Windows, so it seems that the initial problem of this issue is also no more relevant.

Closes #75 