### PR TITLE
feat: add oasVersion into the --format json output

### DIFF
--- a/src/__tests__/detect-oas-version.test.ts
+++ b/src/__tests__/detect-oas-version.test.ts
@@ -1,0 +1,33 @@
+import { parseYamlToDocument, makeConfigForRuleset } from "./utils";
+import { validateDocument } from "../validate";
+import { BaseResolver } from "../resolve";
+
+describe('oas version detection', () => {
+  it('should detect OpenAPI 3.x', async () => {
+    const document = parseYamlToDocument(`
+      openapi: 3.0.2
+      info:
+        title: OpenAPI example
+    `);
+    const { oasVersion } = await validateDocument({
+      document,
+      externalRefResolver: new BaseResolver(),
+      config: makeConfigForRuleset({}),
+    });
+    expect(oasVersion).toEqual('3.0.2');
+  })
+
+  it('should detect Swagger 2.x', async () => {
+    const document = parseYamlToDocument(`
+      swagger: '2.0'
+      info:
+        title: Swagger example
+    `);
+    const { oasVersion } = await validateDocument({
+      document,
+      externalRefResolver: new BaseResolver(),
+      config: makeConfigForRuleset({}),
+    });
+    expect(oasVersion).toEqual('2.0');
+  })
+});

--- a/src/__tests__/ref-utils.test.ts
+++ b/src/__tests__/ref-utils.test.ts
@@ -94,6 +94,11 @@ describe('ref-utils', () => {
       config: new LintConfig({}),
     });
 
-    expect(result).toMatchInlineSnapshot(`Array []`);
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "oasVersion": "3.0.0",
+        "results": Array [],
+      }
+    `);
   });
 });

--- a/src/__tests__/walk.test.ts
+++ b/src/__tests__/walk.test.ts
@@ -1048,7 +1048,7 @@ describe('context.report', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const {results} = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: makeConfigForRuleset(testRuleSet),
@@ -1128,7 +1128,7 @@ describe('context.report', () => {
       throw 'Should never happen';
     }
 
-    const results = await validateDocument({
+    const {results} = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: makeConfigForRuleset(testRuleSet),

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -50,6 +50,7 @@ export async function bundleDocument(opts: {
   const { document, config, customTypes, externalRefResolver, dereference = false } = opts;
   const oasVersion = detectOpenAPI(document.parsed);
   const oasMajorVersion = openAPIMajor(oasVersion);
+  const oasFullVersion = document.parsed.openapi || document.parsed.swagger;
 
   const rules = config.getRulesForOasVersion(oasMajorVersion);
 
@@ -96,6 +97,7 @@ export async function bundleDocument(opts: {
   });
 
   return {
+    oasVersion: oasFullVersion,
     bundle: document.parsed,
     problems: ctx.problems.map((problem) => config.addProblemToIgnore(problem)),
     fileDependencies: externalRefResolver.getFiles(),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -101,7 +101,7 @@ yargs
         try {
           const startedAt = performance.now();
           process.stderr.write(gray(`validating ${entryPoint}...\n`));
-          const results = await validate({
+          const { results, oasVersion } = await validate({
             ref: entryPoint,
             config,
           });
@@ -121,7 +121,8 @@ yargs
               format: argv.format,
               maxProblems: argv['max-problems'],
               totals: fileTotals,
-              version
+              version,
+              oasVersion,
             });
           }
 
@@ -220,7 +221,7 @@ yargs
         try {
           const startedAt = performance.now();
           process.stderr.write(gray(`bundling ${entrypoint}...\n`));
-          const { bundle: result, problems } = await bundle({
+          const { bundle: result, problems, oasVersion } = await bundle({
             config,
             ref: entrypoint,
             dereference: argv.dereferenced,
@@ -254,6 +255,7 @@ yargs
             maxProblems: argv['max-problems'],
             totals: fileTotals,
             version,
+            oasVersion,
           });
 
           const elapsed =

--- a/src/format/format.ts
+++ b/src/format/format.ts
@@ -50,6 +50,7 @@ export function formatProblems(
     color?: boolean;
     totals: Totals;
     version: string;
+    oasVersion: string;
   },
 ) {
   const {
@@ -58,7 +59,8 @@ export function formatProblems(
     format = 'codeframe',
     color = colorOptions.enabled,
     totals,
-    version
+    version,
+    oasVersion,
   } = opts;
 
   colorOptions.enabled = color; // force colors if specified
@@ -111,6 +113,7 @@ export function formatProblems(
   function outputJSON() {
     const resultObject = {
       totals,
+      oasVersion,
       version,
       problems: problems.map((p) => {
         let problem = {

--- a/src/rules/__tests__/no-unresolved-refs.test.ts
+++ b/src/rules/__tests__/no-unresolved-refs.test.ts
@@ -21,7 +21,7 @@ describe('oas3 boolean-parameter-prefixes', () => {
       path.join(__dirname, 'foobar.yaml'),
     );
 
-    const results = await validateDocument({
+    const {results} = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({
@@ -64,7 +64,7 @@ describe('oas3 boolean-parameter-prefixes', () => {
       path.join(__dirname, 'foobar.yaml'),
     );
 
-    const results = await validateDocument({
+    const {results} = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({
@@ -124,7 +124,7 @@ describe('oas3 boolean-parameter-prefixes', () => {
       path.join(__dirname, 'foobar.yaml'),
     );
 
-    const results = await validateDocument({
+    const {results} = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({
@@ -151,7 +151,7 @@ describe('oas3 boolean-parameter-prefixes', () => {
       path.join(__dirname, 'foobar.yaml'),
     );
 
-    const results = await validateDocument({
+    const {results} = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({

--- a/src/rules/common/__tests__/info-description.test.ts
+++ b/src/rules/common/__tests__/info-description.test.ts
@@ -16,7 +16,7 @@ describe('Oas3 info-description', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const {results} = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({
@@ -57,7 +57,7 @@ describe('Oas3 info-description', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const {results} = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({
@@ -97,7 +97,7 @@ describe('Oas3 info-description', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const {results} = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({

--- a/src/rules/common/__tests__/info-license.test.ts
+++ b/src/rules/common/__tests__/info-license.test.ts
@@ -17,7 +17,7 @@ describe('Oas3 info-license', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const {results} = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'info-license': 'error' } }),
@@ -54,7 +54,7 @@ describe('Oas3 info-license', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'info-license': 'error' } }),

--- a/src/rules/common/__tests__/license-url.test.ts
+++ b/src/rules/common/__tests__/license-url.test.ts
@@ -18,7 +18,7 @@ describe('Oas3 license-url', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'info-license-url': 'error' } }),
@@ -55,7 +55,7 @@ describe('Oas3 license-url', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'info-license-url': 'error' } }),

--- a/src/rules/common/__tests__/no-ambiguous-paths.test.ts
+++ b/src/rules/common/__tests__/no-ambiguous-paths.test.ts
@@ -46,7 +46,7 @@ describe('no-ambiguous-paths', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'no-ambiguous-paths': 'error' } }),

--- a/src/rules/common/__tests__/no-enum-type-mismatch.test.ts
+++ b/src/rules/common/__tests__/no-enum-type-mismatch.test.ts
@@ -29,7 +29,7 @@ describe('Oas3 typed enum', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'no-enum-type-mismatch': 'error' } }),
@@ -59,7 +59,7 @@ describe('Oas3 typed enum', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const {results} = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'no-enum-type-mismatch': 'error' } }),

--- a/src/rules/common/__tests__/no-identical-paths.test.ts
+++ b/src/rules/common/__tests__/no-identical-paths.test.ts
@@ -34,7 +34,7 @@ describe('no-identical-paths', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'no-identical-paths': 'error' } }),

--- a/src/rules/common/__tests__/no-path-trailing-slash.test.ts
+++ b/src/rules/common/__tests__/no-path-trailing-slash.test.ts
@@ -19,7 +19,7 @@ describe('no-path-trailing-slash', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'no-path-trailing-slash': 'error' } }),
@@ -56,7 +56,7 @@ describe('no-path-trailing-slash', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'no-path-trailing-slash': 'error' } }),
@@ -77,7 +77,7 @@ describe('no-path-trailing-slash', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'no-path-trailing-slash': 'error' } }),

--- a/src/rules/common/__tests__/operation-2xx-response.test.ts
+++ b/src/rules/common/__tests__/operation-2xx-response.test.ts
@@ -21,7 +21,7 @@ describe('Oas3 operation-2xx-response', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const {results} = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'operation-2xx-response': 'error' } }),
@@ -60,7 +60,7 @@ describe('Oas3 operation-2xx-response', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'operation-2xx-response': 'error' } }),
@@ -83,7 +83,7 @@ describe('Oas3 operation-2xx-response', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'operation-2xx-response': 'error' } }),

--- a/src/rules/common/__tests__/operation-operationId-unique.test.ts
+++ b/src/rules/common/__tests__/operation-operationId-unique.test.ts
@@ -26,7 +26,7 @@ describe('Oas3 operation-operationId-unique', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'operation-operationId-unique': 'error' } }),
@@ -68,7 +68,7 @@ describe('Oas3 operation-operationId-unique', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'peration-operationId-unique': 'error' } }),

--- a/src/rules/common/__tests__/operation-operationId-url-safe.test.ts
+++ b/src/rules/common/__tests__/operation-operationId-url-safe.test.ts
@@ -21,7 +21,7 @@ describe('Oas3 operation-operationId-url-safe', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({

--- a/src/rules/common/__tests__/operation-parameters-unique.test.ts
+++ b/src/rules/common/__tests__/operation-parameters-unique.test.ts
@@ -22,7 +22,7 @@ describe('Oas3 operation-parameters-unique', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({
@@ -68,7 +68,7 @@ describe('Oas3 operation-parameters-unique', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({
@@ -101,7 +101,7 @@ describe('Oas3 operation-parameters-unique', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({
@@ -152,7 +152,7 @@ describe('Oas3 operation-parameters-unique', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({

--- a/src/rules/common/__tests__/operation-security-defined.test.ts
+++ b/src/rules/common/__tests__/operation-security-defined.test.ts
@@ -19,7 +19,7 @@ describe('Oas3 operation-security-defined', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const {results} = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'operation-security-defined': 'error' } }),
@@ -61,7 +61,7 @@ describe('Oas3 operation-security-defined', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'operation-security-defined': 'error' } }),

--- a/src/rules/common/__tests__/operation-singular-tag.test.ts
+++ b/src/rules/common/__tests__/operation-singular-tag.test.ts
@@ -24,7 +24,7 @@ describe('Oas3 operation-singular-tag', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'operation-singular-tag': 'error' } }),
@@ -64,7 +64,7 @@ describe('Oas3 operation-singular-tag', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'operation-singular-tag': 'error' } }),

--- a/src/rules/common/__tests__/path-http-verbs-order.test.ts
+++ b/src/rules/common/__tests__/path-http-verbs-order.test.ts
@@ -23,7 +23,7 @@ describe('Common path-http-verbs-order', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'path-http-verbs-order': 'error' } }),
@@ -87,7 +87,7 @@ describe('Common path-http-verbs-order', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'path-http-verbs-order': 'error' } }),

--- a/src/rules/common/__tests__/path-not-include-query.test.ts
+++ b/src/rules/common/__tests__/path-not-include-query.test.ts
@@ -19,7 +19,7 @@ describe('Oas3 path-not-include-query', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'path-not-include-query': 'error' } }),
@@ -56,7 +56,7 @@ describe('Oas3 path-not-include-query', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'path-not-include-query': 'error' } }),

--- a/src/rules/common/__tests__/path-params-defined.test.ts
+++ b/src/rules/common/__tests__/path-params-defined.test.ts
@@ -24,7 +24,7 @@ describe('Oas3 path-params-defined', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'path-params-defined': 'error' } }),
@@ -52,7 +52,7 @@ describe('Oas3 path-params-defined', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const {results} = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'path-params-defined': 'error' } }),
@@ -96,7 +96,7 @@ describe('Oas3 path-params-defined', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'path-params-defined': 'error' } }),

--- a/src/rules/common/__tests__/paths-kebab-case.test.ts
+++ b/src/rules/common/__tests__/paths-kebab-case.test.ts
@@ -22,7 +22,7 @@ describe('Oas3 paths-kebab-case', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const {results} = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'paths-kebab-case': 'error' } }),

--- a/src/rules/common/__tests__/tag-description.test.ts
+++ b/src/rules/common/__tests__/tag-description.test.ts
@@ -19,7 +19,7 @@ describe('Oas3 tag-description', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'tag-description': 'error' } }),
@@ -57,7 +57,7 @@ describe('Oas3 tag-description', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'tag-description': 'error' } }),

--- a/src/rules/common/__tests__/tags-alphabetical.test.ts
+++ b/src/rules/common/__tests__/tags-alphabetical.test.ts
@@ -19,7 +19,7 @@ describe('Oas3 tags-alphabetical', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'tags-alphabetical': 'error' } }),
@@ -56,7 +56,7 @@ describe('Oas3 tags-alphabetical', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'tags-alphabetical': 'error' } }),

--- a/src/rules/oas2/__tests__/boolean-parameter-prefixes.test.ts
+++ b/src/rules/oas2/__tests__/boolean-parameter-prefixes.test.ts
@@ -20,7 +20,7 @@ describe('oas2 boolean-parameter-prefixes', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'boolean-parameter-prefixes': 'error' } }),
@@ -72,7 +72,7 @@ describe('oas2 boolean-parameter-prefixes', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'boolean-parameter-prefixes': 'error' } }),
@@ -96,7 +96,7 @@ describe('oas2 boolean-parameter-prefixes', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const {results} = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({

--- a/src/rules/oas2/__tests__/spec/referenceableScalars.test.ts
+++ b/src/rules/oas2/__tests__/spec/referenceableScalars.test.ts
@@ -21,7 +21,7 @@ describe('Referenceable scalars', () => {
       __dirname + '/foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({

--- a/src/rules/oas2/__tests__/spec/utils.ts
+++ b/src/rules/oas2/__tests__/spec/utils.ts
@@ -9,7 +9,7 @@ export async function validateDoc(
 ) {
   const document = parseYamlToDocument(source, 'foobar.yaml');
 
-  const results = await validateDocument({
+  const {results} = await validateDocument({
     externalRefResolver: new BaseResolver(),
     document,
     config: new LintConfig({

--- a/src/rules/oas3/__tests__/boolean-parameter-prefixes.test.ts
+++ b/src/rules/oas3/__tests__/boolean-parameter-prefixes.test.ts
@@ -21,7 +21,7 @@ describe('oas3 boolean-parameter-prefixes', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'boolean-parameter-prefixes': 'error' } }),
@@ -73,7 +73,7 @@ describe('oas3 boolean-parameter-prefixes', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const {results} = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'boolean-parameter-prefixes': 'error' } }),
@@ -97,7 +97,7 @@ describe('oas3 boolean-parameter-prefixes', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({

--- a/src/rules/oas3/__tests__/no-example-value-and-externalValue.test.ts
+++ b/src/rules/oas3/__tests__/no-example-value-and-externalValue.test.ts
@@ -20,7 +20,7 @@ describe('Oas3 oas3-no-example-value-and-externalValue', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const {results} = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({
@@ -60,7 +60,7 @@ describe('Oas3 oas3-no-example-value-and-externalValue', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const {results} = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({

--- a/src/rules/oas3/__tests__/no-invalid-media-type-examples.test.ts
+++ b/src/rules/oas3/__tests__/no-invalid-media-type-examples.test.ts
@@ -33,7 +33,7 @@ describe('no-invalid-media-type-examples', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'no-invalid-media-type-examples': 'error' } }),
@@ -106,7 +106,7 @@ describe('no-invalid-media-type-examples', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const {results} = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({
@@ -169,7 +169,7 @@ describe('no-invalid-media-type-examples', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({
@@ -222,7 +222,7 @@ describe('no-invalid-media-type-examples', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({
@@ -278,7 +278,7 @@ describe('no-invalid-media-type-examples', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const {results} = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'no-invalid-media-type-examples': 'error' } }),
@@ -310,7 +310,7 @@ describe('no-invalid-media-type-examples', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const {results} = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'no-invalid-media-type-examples': 'error' } }),

--- a/src/rules/oas3/__tests__/no-server-example.com.test.ts
+++ b/src/rules/oas3/__tests__/no-server-example.com.test.ts
@@ -17,7 +17,7 @@ describe('Oas3 oas3-no-server-example.com', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'no-server-example.com': 'error' } }),
@@ -52,7 +52,7 @@ describe('Oas3 oas3-no-server-example.com', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'no-server-example.com': 'error' } }),

--- a/src/rules/oas3/__tests__/no-server-trailing-slash.test.ts
+++ b/src/rules/oas3/__tests__/no-server-trailing-slash.test.ts
@@ -17,7 +17,7 @@ describe('Oas3 oas3-no-server-trailing-slash', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'no-server-trailing-slash': 'error' } }),
@@ -52,7 +52,7 @@ describe('Oas3 oas3-no-server-trailing-slash', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const {results} = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'no-server-trailing-slash': 'error' } }),

--- a/src/rules/oas3/__tests__/no-unused-components.test.ts
+++ b/src/rules/oas3/__tests__/no-unused-components.test.ts
@@ -42,7 +42,7 @@ describe('Oas3 no-unused-components', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({ extends: [], rules: { 'no-unused-components': 'error' } }),

--- a/src/rules/oas3/__tests__/spec/referenceableScalars.test.ts
+++ b/src/rules/oas3/__tests__/spec/referenceableScalars.test.ts
@@ -21,7 +21,7 @@ describe('Referenceable scalars', () => {
       __dirname + '/foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: new LintConfig({

--- a/src/rules/oas3/__tests__/spec/spec.test.ts
+++ b/src/rules/oas3/__tests__/spec/spec.test.ts
@@ -37,7 +37,7 @@ describe('Oas3 Structural visitor basic', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: allConfig,
@@ -165,7 +165,7 @@ describe('Oas3 Structural visitor basic', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const { results } = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: allConfig,
@@ -234,7 +234,7 @@ describe('Oas3 Structural visitor basic', () => {
       'foobar.yaml',
     );
 
-    const results = await validateDocument({
+    const {results} = await validateDocument({
       externalRefResolver: new BaseResolver(),
       document,
       config: allConfig,

--- a/src/rules/oas3/__tests__/spec/utils.ts
+++ b/src/rules/oas3/__tests__/spec/utils.ts
@@ -9,7 +9,7 @@ export async function validateDoc(
 ) {
   const document = parseYamlToDocument(source, 'foobar.yaml');
 
-  const results = await validateDocument({
+  const {results} = await validateDocument({
     externalRefResolver: new BaseResolver(),
     document,
     config: new LintConfig({

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -60,6 +60,7 @@ export async function validateDocument(opts: {
   const { document, customTypes, externalRefResolver, config } = opts;
   const oasVersion = detectOpenAPI(document.parsed);
   const oasMajorVersion = openAPIMajor(oasVersion);
+  const oasFullVersion = document.parsed.openapi || document.parsed.swagger;
 
   const rules = config.getRulesForOasVersion(oasMajorVersion);
   const types = normalizeTypes(
@@ -93,7 +94,10 @@ export async function validateDocument(opts: {
     ctx,
   });
 
-  return ctx.problems.map((problem) => config.addProblemToIgnore(problem));
+  return {
+    results: ctx.problems.map((problem) => config.addProblemToIgnore(problem)),
+    oasVersion: oasFullVersion,
+  };
 }
 
 export function detectOpenAPI(root: any): OasVersion {


### PR DESCRIPTION
For now, it adds an `oasVersion` field to the top of the resulting JSON object. However, in the near future, we might consider adding smth like `meta` to store an increasing number of additional info.

```jsonc
{
  "oasVersion": "3.0.0",
  // ...
}
```