### PR TITLE
fix: node-fetch cve-2020-15168

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "js-yaml": "^3.14.0",
     "lodash.isequal": "^4.5.0",
     "minimatch": "^3.0.4",
-    "node-fetch": "^2.6.0",
+    "node-fetch": "^2.6.1",
     "portfinder": "^1.0.26",
     "readline": "^1.3.0",
     "simple-websocket": "^9.0.0",


### PR DESCRIPTION
Bump node-fetch to 2.6.1 to address:

https://github.com/advisories/GHSA-w7rc-rwvf-8q5r