### PR TITLE
docs: fix readme usage of spec vs definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ npx @redocly/openapi-cli lint path-to-root-file.yaml
 
 ### Docker
 
-To give the docker container access to the OpenAPI spec files, you need to
-mount the containing directory as a volume. Assuming the spec is rooted
+To give the docker container access to the OpenAPI definition files, you need to
+mount the containing directory as a volume. Assuming the OAS defintion is rooted
 in the current working directory, you need the following command:
 
 ```


### PR DESCRIPTION
We use "definition" instead of "spec" to refer to the OpenAPI documents created by users (we use "spec" to refer to the OpenAPI specification itself).