### PR TITLE
chore: export a util function from openapi-core and move change registry rule to decorators

### DIFF
--- a/__mocks__/@redocly/openapi-core.ts
+++ b/__mocks__/@redocly/openapi-core.ts
@@ -14,3 +14,4 @@ export const __redoclyClient = {
 export const RedoclyClient = jest.fn(() => __redoclyClient);
 export const loadConfig = jest.fn(() => ({ configFile: null }));
 export const bundle = jest.fn(() => ({ bundle: { parsed: null }, problems: null }));
+export const getTotals = jest.fn(() => ({ errors: 0 }));

--- a/packages/cli/src/commands/bundle.ts
+++ b/packages/cli/src/commands/bundle.ts
@@ -1,30 +1,32 @@
-import { bundle, formatProblems, loadConfig, OutputFormat } from '@redocly/openapi-core';
+import { bundle, formatProblems, getTotals, loadConfig, OutputFormat } from '@redocly/openapi-core';
 import {
   dumpBundle,
   getExecutionTime,
   getFallbackEntryPointsOrExit,
   getOutputFileName,
-  getTotals, handleError, printUnusedWarnings,
+  handleError,
+  printUnusedWarnings,
   saveBundle,
 } from '../utils';
 import { OutputExtensions, Totals } from '../types';
-import { performance } from "perf_hooks";
+import { performance } from 'perf_hooks';
 import { blue, gray, green, yellow } from 'colorette';
 
-export async function handleBundle (argv: {
-  entrypoints: string[];
-  output?: string;
-  ext: OutputExtensions;
-  'max-problems'?: number;
-  'skip-rule'?: string[];
-  'skip-preprocessor'?: string[];
-  'skip-decorator'?: string[];
-  dereferenced?: boolean;
-  force?: boolean;
-  config?: string;
-  format: OutputFormat;
-},
-version: string
+export async function handleBundle(
+  argv: {
+    entrypoints: string[];
+    output?: string;
+    ext: OutputExtensions;
+    'max-problems'?: number;
+    'skip-rule'?: string[];
+    'skip-preprocessor'?: string[];
+    'skip-decorator'?: string[];
+    dereferenced?: boolean;
+    force?: boolean;
+    config?: string;
+    format: OutputFormat;
+  },
+  version: string,
 ) {
   const config = await loadConfig(argv.config);
   config.lint.skipRules(argv['skip-rule']);
@@ -76,11 +78,9 @@ version: string
       if (fileTotals.errors > 0) {
         if (argv.force) {
           process.stderr.write(
-            `❓ Created a bundle for ${blue(entrypoint)} at ${blue(
-              outputFile,
-            )} with errors ${green(elapsed)}.\n${yellow(
-              'Errors ignored because of --force',
-            )}.\n`,
+            `❓ Created a bundle for ${blue(entrypoint)} at ${blue(outputFile)} with errors ${green(
+              elapsed,
+            )}.\n${yellow('Errors ignored because of --force')}.\n`,
           );
         } else {
           process.stderr.write(
@@ -91,9 +91,7 @@ version: string
         }
       } else {
         process.stderr.write(
-          `📦 Created a bundle for ${blue(entrypoint)} at ${blue(outputFile)} ${green(
-            elapsed,
-          )}.\n`,
+          `📦 Created a bundle for ${blue(entrypoint)} at ${blue(outputFile)} ${green(elapsed)}.\n`,
         );
       }
     } catch (e) {

--- a/packages/cli/src/commands/join.ts
+++ b/packages/cli/src/commands/join.ts
@@ -12,13 +12,13 @@ import {
   Oas3Tag,
   loadConfig,
   formatProblems,
+  getTotals,
   lintDocument,
   detectOpenAPI,
 } from '@redocly/openapi-core';
 
 import {
   getFallbackEntryPointsOrExit,
-  getTotals,
   printExecutionTime,
   handleError,
   printLintTotals,

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -1,28 +1,35 @@
-import { Config, formatProblems, lint, loadConfig, OutputFormat } from '@redocly/openapi-core';
+import {
+  Config,
+  formatProblems,
+  getTotals,
+  lint,
+  loadConfig,
+  OutputFormat,
+} from '@redocly/openapi-core';
 import {
   getExecutionTime,
   getFallbackEntryPointsOrExit,
-  getTotals,
   handleError,
   pluralize,
   printLintTotals,
-  printUnusedWarnings
+  printUnusedWarnings,
 } from '../utils';
 import { Totals } from '../types';
 import { blue, gray } from 'colorette';
-import { performance } from "perf_hooks";
+import { performance } from 'perf_hooks';
 
-export async function handleLint (argv: {
-  entrypoints: string[];
-  'max-problems'?: number;
-  'generate-ignore-file'?: boolean;
-  'skip-rule'?: string[];
-  'skip-preprocessor'?: string[];
-  extends?: string[];
-  config?: string;
-  format: OutputFormat;
-},
-  version: string
+export async function handleLint(
+  argv: {
+    entrypoints: string[];
+    'max-problems'?: number;
+    'generate-ignore-file'?: boolean;
+    'skip-rule'?: string[];
+    'skip-preprocessor'?: string[];
+    extends?: string[];
+    config?: string;
+    format: OutputFormat;
+  },
+  version: string,
 ) {
   const config: Config = await loadConfig(argv.config, argv.extends);
   config.lint.skipRules(argv['skip-rule']);
@@ -35,7 +42,9 @@ export async function handleLint (argv: {
   let totalIgnored = 0;
   if (config.lint.recommendedFallback) {
     process.stderr.write(
-      `No configurations were defined in extends -- using built in ${blue('recommended')} configuration by default.\n\n`,
+      `No configurations were defined in extends -- using built in ${blue(
+        'recommended',
+      )} configuration by default.\n\n`,
     );
   }
 
@@ -64,7 +73,7 @@ export async function handleLint (argv: {
           format: argv.format,
           maxProblems: argv['max-problems'],
           totals: fileTotals,
-          version
+          version,
         });
       }
 

--- a/packages/cli/src/commands/preview-docs/index.ts
+++ b/packages/cli/src/commands/preview-docs/index.ts
@@ -1,7 +1,7 @@
 import * as colorette from 'colorette';
 import * as chockidar from 'chokidar';
-import { bundle, loadConfig, ResolveError, YamlParseError, RedoclyClient } from "@redocly/openapi-core";
-import { getFallbackEntryPointsOrExit, getTotals } from '../../utils';
+import { bundle, loadConfig, ResolveError, YamlParseError, RedoclyClient, getTotals } from "@redocly/openapi-core";
+import { getFallbackEntryPointsOrExit } from '../../utils';
 import startPreviewServer from './preview-server/preview-server';
 
 export async function previewDocs(argv: {

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -5,13 +5,12 @@ import { performance } from 'perf_hooks';
 import { yellow, green, blue } from 'colorette';
 import { createHash } from 'crypto';
 
-import { bundle, Config, loadConfig, RedoclyClient, IGNORE_FILE, BundleOutputFormat } from '@redocly/openapi-core';
+import { bundle, Config, loadConfig, RedoclyClient, IGNORE_FILE, BundleOutputFormat, getTotals, } from '@redocly/openapi-core';
 import {
   promptUser,
   exitWithError,
   printExecutionTime,
   getFallbackEntryPointsOrExit,
-  getTotals,
   pluralize,
   dumpBundle,
   slash

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -5,7 +5,7 @@ import { performance } from 'perf_hooks';
 import { yellow, green, blue } from 'colorette';
 import { createHash } from 'crypto';
 
-import { bundle, Config, loadConfig, RedoclyClient, IGNORE_FILE, BundleOutputFormat, getTotals, } from '@redocly/openapi-core';
+import { bundle, Config, loadConfig, RedoclyClient, IGNORE_FILE, BundleOutputFormat, getTotals } from '@redocly/openapi-core';
 import {
   promptUser,
   exitWithError,

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -11,7 +11,6 @@ import {
   BundleOutputFormat,
   Config,
   LintConfig,
-  NormalizedProblem,
   ResolveError,
   YamlParseError,
 } from '@redocly/openapi-core';
@@ -48,27 +47,6 @@ async function expandGlobsInEntrypoints(args: string[], config: Config) {
       ? (await glob(aliasOrPath)).map((g: string) => getAliasOrPath(config, g))
       : getAliasOrPath(config, aliasOrPath);
   }))).flat();
-}
-
-export function getTotals(problems: (NormalizedProblem & { ignored?: boolean })[]): Totals {
-  let errors = 0;
-  let warnings = 0;
-  let ignored = 0;
-
-  for (const m of problems) {
-    if (m.ignored) {
-      ignored++;
-      continue;
-    }
-    if (m.severity === 'error') errors++;
-    if (m.severity === 'warn') warnings++;
-  }
-
-  return {
-    errors,
-    warnings,
-    ignored,
-  };
 }
 
 export function getExecutionTime(startedAt: number) {

--- a/packages/core/src/config/builtIn.ts
+++ b/packages/core/src/config/builtIn.ts
@@ -7,4 +7,7 @@ export const builtInConfigs: Record<string, LintRawConfig> = {
   recommended,
   minimal,
   all,
+  'redocly-registry': {
+    decorators: { 'registry-dependencies': 'on' }
+  }
 };

--- a/packages/core/src/format/format.ts
+++ b/packages/core/src/format/format.ts
@@ -10,7 +10,7 @@ import {
   red,
 } from 'colorette';
 
-const coreVersion = require('../package.json').version;
+const coreVersion = require('../../package.json').version;
 
 import { NormalizedProblem, ProblemSeverity, LineColLocationObject, LocationObject } from '../walk';
 import { getCodeframe, getLineColLocation } from './codeframes';

--- a/packages/core/src/format/format.ts
+++ b/packages/core/src/format/format.ts
@@ -10,15 +10,16 @@ import {
   red,
 } from 'colorette';
 
+const coreVersion = require('../package.json').version;
+
 import { NormalizedProblem, ProblemSeverity, LineColLocationObject, LocationObject } from '../walk';
 import { getCodeframe, getLineColLocation } from './codeframes';
 
-type Totals = {
+export type Totals = {
 	errors: number;
 	warnings: number;
 	ignored: number;
 }
-
 
 const ERROR_MESSAGE = {
   INVALID_SEVERITY_LEVEL: 'Invalid severity level; accepted values: error or warn',
@@ -47,6 +48,27 @@ function severityToNumber(severity: ProblemSeverity) {
 
 export type OutputFormat = 'codeframe' | 'stylish' | 'json';
 
+export function getTotals(problems: (NormalizedProblem & { ignored?: boolean })[]): Totals {
+  let errors = 0;
+  let warnings = 0;
+  let ignored = 0;
+
+  for (const m of problems) {
+    if (m.ignored) {
+      ignored++;
+      continue;
+    }
+    if (m.severity === 'error') errors++;
+    if (m.severity === 'warn') warnings++;
+  }
+
+  return {
+    errors,
+    warnings,
+    ignored,
+  };
+}
+
 export function formatProblems(
   problems: (NormalizedProblem & { ignored?: boolean })[],
   opts: {
@@ -54,7 +76,7 @@ export function formatProblems(
     cwd?: string;
     format?: OutputFormat;
     color?: boolean;
-    totals: Totals;
+    totals: Totals
     version: string;
   },
 ) {
@@ -63,8 +85,8 @@ export function formatProblems(
     cwd = process.cwd(),
     format = 'codeframe',
     color = colorOptions.enabled,
-    totals,
-    version
+    totals = getTotals(problems),
+    version = coreVersion,
   } = opts;
 
   colorOptions.enabled = color; // force colors if specified

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,6 @@ export { detectOpenAPI, OasMajorVersion, openAPIMajor } from './lint';
 export { normalizeVisitors } from './visitors';
 export { WalkContext, walkDocument, NormalizedProblem, ProblemSeverity, LineColLocationObject, LocationObject, Loc } from './walk';
 
-export { formatProblems, OutputFormat } from './format/format';
+export { formatProblems, OutputFormat, getTotals, Totals } from './format/format';
 export { OasVersion, lint, lint as validate, lintDocument } from './lint';
 export { bundle } from './bundle';

--- a/packages/core/src/rules/common/registry-dependencies.ts
+++ b/packages/core/src/rules/common/registry-dependencies.ts
@@ -1,8 +1,8 @@
 import { RedoclyClient } from '../../redocly';
 
-import { Oas3Rule, Oas2Rule } from '../../visitors';
+import { Oas3Decorator, Oas2Decorator } from '../../visitors';
 
-export const RegistryDependencies: Oas3Rule | Oas2Rule = () => {
+export const RegistryDependencies: Oas3Decorator | Oas2Decorator = () => {
   let redoclyClient: RedoclyClient;
   let registryDependencies = new Set<string>();
 

--- a/packages/core/src/rules/oas2/index.ts
+++ b/packages/core/src/rules/oas2/index.ts
@@ -24,7 +24,7 @@ import { OperationSingularTag } from '../common/operation-singular-tag';
 import { OperationSecurityDefined } from '../common/operation-security-defined';
 import { NoUnresolvedRefs } from '../no-unresolved-refs';
 import { PathHttpVerbsOrder } from '../common/path-http-verbs-order';
-import { Oas2Rule } from '../../visitors';
+import { Oas2Decorator, Oas2Rule } from '../../visitors';
 import { RegistryDependencies } from '../common/registry-dependencies';
 import { NoIdenticalPaths } from '../common/no-identical-paths';
 import { OperationOperationId } from '../common/operation-operationId';
@@ -74,5 +74,5 @@ export const rules = {
 
 export const preprocessors = {};
 export const decorators = {
-  'registry-dependencies': RegistryDependencies as Oas2Rule,
+  'registry-dependencies': RegistryDependencies as Oas2Decorator,
 };

--- a/packages/core/src/rules/oas2/index.ts
+++ b/packages/core/src/rules/oas2/index.ts
@@ -69,9 +69,10 @@ export const rules = {
 
   'path-http-verbs-order': PathHttpVerbsOrder as Oas2Rule,
 
-  'registry-dependencies': RegistryDependencies as Oas2Rule,
   spec: OasSpec as Oas2Rule,
 };
 
 export const preprocessors = {};
-export const decorators = {};
+export const decorators = {
+  'registry-dependencies': RegistryDependencies as Oas2Rule,
+};

--- a/packages/core/src/rules/oas3/index.ts
+++ b/packages/core/src/rules/oas3/index.ts
@@ -72,7 +72,6 @@ export const rules = {
   'boolean-parameter-prefixes': BooleanParameterPrefixes,
   'path-http-verbs-order': PathHttpVerbsOrder,
   'no-invalid-media-type-examples': ValidContentExamples,
-  'registry-dependencies': RegistryDependencies,
   'no-identical-paths': NoIdenticalPaths,
   'no-ambiguous-paths': NoAmbiguousPaths,
   'no-undefined-server-variable': NoUndefinedServerVariable,
@@ -81,4 +80,6 @@ export const rules = {
 
 export const preprocessors = {};
 
-export const decorators = {};
+export const decorators = {
+  'registry-dependencies': RegistryDependencies,
+};

--- a/packages/core/src/rules/oas3/index.ts
+++ b/packages/core/src/rules/oas3/index.ts
@@ -38,6 +38,8 @@ import { OperationOperationId } from '../common/operation-operationId';
 import { OperationSummary } from '../common/operation-summary';
 import { NoAmbiguousPaths } from '../common/no-ambiguous-paths';
 
+import { Oas3Decorator } from '../../visitors';
+
 export const rules = {
   'info-description': InfoDescription,
   'info-contact': InfoContact,
@@ -81,5 +83,5 @@ export const rules = {
 export const preprocessors = {};
 
 export const decorators = {
-  'registry-dependencies': RegistryDependencies,
+  'registry-dependencies': RegistryDependencies as Oas3Decorator,
 };


### PR DESCRIPTION
- export `getTotals` for usage in portal
- added some default values for `formatMessages` util function
- change `registry-dependencies` rule to be a decorator
- add built-in ruleset to be used in redocly registry (with `registry-dependencies` decorator enabled)