### PR TITLE
fix: fix multiple-file transitive refs resolution

### DIFF
--- a/packages/core/__tests__/fixtures/resolve/transitive/a.yaml
+++ b/packages/core/__tests__/fixtures/resolve/transitive/a.yaml
@@ -1,0 +1,1 @@
+type: string

--- a/packages/core/__tests__/fixtures/resolve/transitive/components.yaml
+++ b/packages/core/__tests__/fixtures/resolve/transitive/components.yaml
@@ -1,3 +1,5 @@
 components:
   schemas:
     $ref: ./schemas.yaml#/schemas
+  shouldNotCrash:
+    $ref: ./schemas.yaml#invalid-hash-fragment

--- a/packages/core/__tests__/fixtures/resolve/transitive/components.yaml
+++ b/packages/core/__tests__/fixtures/resolve/transitive/components.yaml
@@ -1,0 +1,3 @@
+components:
+  schemas:
+    $ref: ./schemas.yaml#/schemas

--- a/packages/core/__tests__/fixtures/resolve/transitive/schemas.yaml
+++ b/packages/core/__tests__/fixtures/resolve/transitive/schemas.yaml
@@ -1,0 +1,3 @@
+schemas:
+  a:
+    $ref: a.yaml

--- a/packages/core/__tests__/resolve.test.ts
+++ b/packages/core/__tests__/resolve.test.ts
@@ -385,7 +385,7 @@ describe('collect refs', () => {
     });
 
     expect(resolvedRefs).toBeDefined();
-    // expect(resolvedRefs.size).toEqual(2);
+    expect(resolvedRefs.size).toEqual(3);
     expect(Array.from(resolvedRefs.keys()).map((ref) => ref.substring(cwd.length + 1))).toEqual([
       'transitive/components.yaml::./schemas.yaml#/schemas',
       'transitive/schemas.yaml::a.yaml',

--- a/packages/core/__tests__/resolve.test.ts
+++ b/packages/core/__tests__/resolve.test.ts
@@ -192,7 +192,8 @@ describe('collect refs', () => {
 
     expect(resolvedRefs).toBeDefined();
 
-    expect(Array.from(resolvedRefs.keys()).map((ref) => ref.substring(cwd.length + 1))).toMatchInlineSnapshot(`
+    expect(Array.from(resolvedRefs.keys()).map((ref) => ref.substring(cwd.length + 1)))
+      .toMatchInlineSnapshot(`
       Array [
         "openapi-with-back.yaml::./schemas/type-a.yaml#/",
         "openapi-with-back.yaml::./schemas/type-b.yaml#/",
@@ -346,12 +347,13 @@ describe('collect refs', () => {
     const resolvedRefs = await resolveDocument({
       rootDocument: rootDocument as Document,
       externalRefResolver: externalRefResolver,
-      rootType: normalizeTypes(Oas3Types).DefinitionRoot
+      rootType: normalizeTypes(Oas3Types).DefinitionRoot,
     });
 
     expect(resolvedRefs).toBeDefined();
     // expect(resolvedRefs.size).toEqual(2);
-    expect(Array.from(resolvedRefs.keys()).map((ref) => ref.substring(cwd.length + 1))).toMatchInlineSnapshot(`
+    expect(Array.from(resolvedRefs.keys()).map((ref) => ref.substring(cwd.length + 1)))
+      .toMatchInlineSnapshot(`
       Array [
         "openapi-with-md-description.yaml::./description.md",
       ]
@@ -363,5 +365,35 @@ describe('collect refs', () => {
       Lorem ipsum",
       ]
     `);
+  });
+
+  it('should resolve external transitive ref', async () => {
+    const cwd = path.join(__dirname, 'fixtures/resolve');
+    const rootDocument = parseYamlToDocument(
+      outdent`
+        openapi: 3.0.0
+        components:
+          $ref: "./transitive/components.yaml#/components/schemas/a"
+      `,
+      path.join(cwd, 'foobar.yaml'),
+    );
+
+    const resolvedRefs = await resolveDocument({
+      rootDocument,
+      externalRefResolver: new BaseResolver(),
+      rootType: normalizeTypes(Oas3Types).DefinitionRoot,
+    });
+
+    expect(resolvedRefs).toBeDefined();
+    // expect(resolvedRefs.size).toEqual(2);
+    expect(Array.from(resolvedRefs.keys()).map((ref) => ref.substring(cwd.length + 1))).toEqual([
+      'transitive/components.yaml::./schemas.yaml#/schemas',
+      'transitive/schemas.yaml::a.yaml',
+      'foobar.yaml::./transitive/components.yaml#/components/schemas/a',
+    ]);
+
+    expect(Array.from(resolvedRefs.values()).pop()!.node).toEqual(
+      { type: 'string' },
+    );
   });
 });

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -338,6 +338,11 @@ export async function resolveDocument(opts: {
           resolvedRef = await followRef(targetDoc, target, pushRef(refStack, target));
           targetDoc = resolvedRef.document || targetDoc;
 
+          if (!resolvedRef.node) {
+            target = undefined;
+            break;
+          }
+
           target = resolvedRef.node[segment];
           resolvedRef.nodePointer = joinPointer(resolvedRef.nodePointer!, escapePointer(segment));
         } else {

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -336,6 +336,8 @@ export async function resolveDocument(opts: {
           resolvedRef.nodePointer = joinPointer(resolvedRef.nodePointer!, escapePointer(segment));
         } else if (isRef(target)) {
           resolvedRef = await followRef(targetDoc, target, pushRef(refStack, target));
+          targetDoc = resolvedRef.document || targetDoc;
+
           target = resolvedRef.node[segment];
           resolvedRef.nodePointer = joinPointer(resolvedRef.nodePointer!, escapePointer(segment));
         } else {
@@ -345,6 +347,7 @@ export async function resolveDocument(opts: {
       }
 
       resolvedRef.node = target;
+      resolvedRef.document = targetDoc;
       const refId = document.source.absoluteRef + '::' + ref.$ref;
 
       if (resolvedRef.document && isRef(target)) {

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -338,7 +338,7 @@ export async function resolveDocument(opts: {
           resolvedRef = await followRef(targetDoc, target, pushRef(refStack, target));
           targetDoc = resolvedRef.document || targetDoc;
 
-          if (!resolvedRef.node) {
+          if (typeof resolvedRef.node !== 'object') {
             target = undefined;
             break;
           }


### PR DESCRIPTION
Transitive $refs links spanning multiple files crashed the resolve step.