### PR TITLE
fix: always parse root document

### DIFF
--- a/packages/cli/src/commands/join.ts
+++ b/packages/cli/src/commands/join.ts
@@ -55,7 +55,7 @@ packageVersion: string
   const entrypoints = await getFallbackEntryPointsOrExit(argv.entrypoints, config);
   const externalRefResolver = new BaseResolver(config.resolve);
   const documents = await Promise.all(
-    entrypoints.map(ref => externalRefResolver.resolveDocument(null, ref) as Promise<Document>)
+    entrypoints.map(ref => externalRefResolver.resolveDocument(null, ref, true) as Promise<Document>)
   );
 
   for (const document of documents) {

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -33,7 +33,7 @@ export async function bundle(opts: {
     throw new Error('Document or reference is required.\n');
   }
 
-  const document = doc !== undefined ? doc : await externalRefResolver.resolveDocument(base, ref!);
+  const document = doc !== undefined ? doc : await externalRefResolver.resolveDocument(base, ref!, true);
 
   if (document instanceof Error) {
     throw document;

--- a/packages/core/src/lint.ts
+++ b/packages/core/src/lint.ts
@@ -39,7 +39,7 @@ export async function lint(opts: {
   externalRefResolver?: BaseResolver;
 }) {
   const { ref, externalRefResolver = new BaseResolver(opts.config.resolve) } = opts;
-  const document = (await externalRefResolver.resolveDocument(null, ref)) as Document;
+  const document = (await externalRefResolver.resolveDocument(null, ref, true)) as Document;
 
   return lintDocument({
     document,

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -107,11 +107,12 @@ export class BaseResolver {
     }
   }
 
-  parseDocument(source: Source): Document {
+  parseDocument(source: Source, isRoot: boolean = false): Document {
     const ext = source.absoluteRef.substr(source.absoluteRef.lastIndexOf('.'));
     if (
       !['.json', '.json', '.yml', '.yaml'].includes(ext) &&
-      !source.mimeType?.match(/(json|yaml)/)
+      !source.mimeType?.match(/(json|yaml)/) &&
+      !isRoot // always parse root
     ) {
       return { source, parsed: source.body };
     }
@@ -129,6 +130,7 @@ export class BaseResolver {
   async resolveDocument(
     base: string | null,
     ref: string,
+    isRoot: boolean = false
   ): Promise<Document | ResolveError | YamlParseError> {
     const absoluteRef = this.resolveExternalRef(base, ref);
     const cachedDocument = this.cache.get(absoluteRef);
@@ -137,7 +139,7 @@ export class BaseResolver {
     }
 
     const doc = this.loadExternalRef(absoluteRef).then((source) => {
-      return this.parseDocument(source);
+      return this.parseDocument(source, isRoot);
     });
 
     this.cache.set(absoluteRef, doc);

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -111,7 +111,7 @@ export class BaseResolver {
     const ext = source.absoluteRef.substr(source.absoluteRef.lastIndexOf('.'));
     if (
       !['.json', '.json', '.yml', '.yaml'].includes(ext) &&
-      !source.mimeType?.match(/(json|yaml)/) &&
+      !source.mimeType?.match(/(json|yaml|openapi)/) &&
       !isRoot // always parse root
     ) {
       return { source, parsed: source.body };


### PR DESCRIPTION
Parse root document using yaml/json parser regardless of file extension/mime-types.

related to https://github.com/Redocly/redoc/issues/1573