### PR TITLE
chore: resolve fs lib on browser in core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "https://github.com/Redocly/openapi-cli.git"
   },
+  "browser": {
+    "fs": false
+  },
   "homepage": "https://github.com/Redocly/openapi-cli",
   "keywords": [
     "linter",


### PR DESCRIPTION
This change is allowed to resolve file system lib on the browser for libs that using openapi-core as a dependency.

Fixes the issue as: `Module not found: Can't resolve 'fs'`