### PR TITLE
Update the year to 2021 and Add License Header

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,6 @@
-Copyright 2019 Redocly LLC
+MIT License
+
+Copyright (c) 2021 Redocly LLC. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
I have updated the year from 2019 to 2021 and also added **MIT License**  header to the license to make more clear and updated.