### PR TITLE
Clone plugin structures rather than change in-place

### DIFF
--- a/packages/core/src/config/__tests__/fixtures/plugin-config.yaml
+++ b/packages/core/src/config/__tests__/fixtures/plugin-config.yaml
@@ -1,0 +1,3 @@
+lint:
+  plugins:
+    - './plugin.js'

--- a/packages/core/src/config/__tests__/fixtures/plugin.js
+++ b/packages/core/src/config/__tests__/fixtures/plugin.js
@@ -1,0 +1,56 @@
+const id = 'test-plugin';
+
+/** @type {import('../../config').PreprocessorsConfig} */
+const preprocessors = {
+  oas2: {
+    'description-preprocessor': () => {
+      return {
+        Info(info) {
+          const title = info.title || 'API title';
+          info.description = `# ${title}\n\n${info.description || ''}`;
+        },
+      };
+    },
+  },
+};
+
+/** @type {import('../../config').CustomRulesConfig} */
+const rules = {
+  oas3: {
+    'openid-connect-url-well-known': () => {
+      return {
+        SecurityScheme(scheme, { location, report }) {
+          if (scheme.type === 'openIdConnect') {
+            if (!scheme.openIdConnectUrl?.endsWith('/.well-known/openid-configuration')) {
+              report({
+                message:
+                  'openIdConnectUrl must be a URL that ends with /.well-known/openid-configuration',
+                location: location.child('openIdConnectUrl'),
+              });
+            }
+          }
+        },
+      };
+    },
+  },
+};
+
+/** @type {import('../../config').DecoratorsConfig} */
+const decorators = {
+  oas3: {
+    'inject-x-stats': () => {
+      return {
+        Info(info) {
+          info['x-stats'] = { test: 1 };
+        },
+      };
+    },
+  },
+};
+
+module.exports = {
+  id,
+  preprocessors,
+  rules,
+  decorators,
+};

--- a/packages/core/src/config/__tests__/resolve-plugins.test.ts
+++ b/packages/core/src/config/__tests__/resolve-plugins.test.ts
@@ -1,0 +1,27 @@
+import * as path from 'path';
+import { loadConfig } from '../config';
+
+describe('resolving a plugin', () => {
+  const configPath = path.join(__dirname, 'fixtures/plugin-config.yaml');
+
+  it('should prefix rule names with the plugin id', async () => {
+    const config = await loadConfig(configPath);
+    const plugin = config.lint.plugins[0];
+
+    expect(plugin.rules?.oas3).toHaveProperty('test-plugin/openid-connect-url-well-known');
+  });
+
+  it('should prefix preprocessor names with the plugin id', async () => {
+    const config = await loadConfig(configPath);
+    const plugin = config.lint.plugins[0];
+
+    expect(plugin.preprocessors?.oas2).toHaveProperty('test-plugin/description-preprocessor');
+  });
+
+  it('should prefix decorator names with the plugin id', async () => {
+    const config = await loadConfig(configPath);
+    const plugin = config.lint.plugins[0];
+
+    expect(plugin.decorators?.oas3).toHaveProperty('test-plugin/inject-x-stats');
+  });
+});

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -192,10 +192,11 @@ export class LintConfig {
     /* no crash when using it on the client */
     if (fs.hasOwnProperty('existsSync') && fs.existsSync(ignoreFile)) {
       // TODO: parse errors
-      this.ignore = yaml.safeLoad(fs.readFileSync(ignoreFile, 'utf-8')) as Record<
-        string,
-        Record<string, Set<string>>
-      > || {};
+      this.ignore =
+        (yaml.safeLoad(fs.readFileSync(ignoreFile, 'utf-8')) as Record<
+          string,
+          Record<string, Set<string>>
+        >) || {};
 
       // resolve ignore paths
       for (const fileName of Object.keys(this.ignore)) {
@@ -483,12 +484,12 @@ function resolvePlugins(plugins: (string | Plugin)[] | null, configPath: string 
   return plugins
     .map((p) => {
       // TODO: resolve npm packages similar to eslint
-      const plugin =
+      const pluginModule =
         typeof p === 'string'
           ? (requireFunc(path.resolve(path.dirname(configPath), p)) as Plugin)
           : p;
 
-      const id = plugin.id;
+      const id = pluginModule.id;
       if (!id) {
         throw new Error(red(`Plugin must define \`id\` property in ${blue(p.toString())}.`));
       }
@@ -506,40 +507,49 @@ function resolvePlugins(plugins: (string | Plugin)[] | null, configPath: string 
 
       seenPluginIds.set(id, p.toString());
 
-      if (plugin.rules) {
-        if (!plugin.rules.oas3 && !plugin.rules.oas2) {
+      const plugin: Plugin = {
+        id,
+        ...(pluginModule.configs ? { configs: pluginModule.configs } : {}),
+        ...(pluginModule.typeExtension ? { typeExtension: pluginModule.typeExtension } : {}),
+      };
+
+      if (pluginModule.rules) {
+        if (!pluginModule.rules.oas3 && !pluginModule.rules.oas2) {
           throw new Error(`Plugin rules must have \`oas3\` or \`oas2\` rules "${p}.`);
         }
-        if (plugin.rules.oas3) {
-          plugin.rules.oas3 = prefixRules(plugin.rules.oas3, id);
+        plugin.rules = {};
+        if (pluginModule.rules.oas3) {
+          plugin.rules.oas3 = prefixRules(pluginModule.rules.oas3, id);
         }
-        if (plugin.rules.oas2) {
-          plugin.rules.oas2 = prefixRules(plugin.rules.oas2, id);
+        if (pluginModule.rules.oas2) {
+          plugin.rules.oas2 = prefixRules(pluginModule.rules.oas2, id);
         }
       }
-      if (plugin.preprocessors) {
-        if (!plugin.preprocessors.oas3 && !plugin.preprocessors.oas2) {
+      if (pluginModule.preprocessors) {
+        if (!pluginModule.preprocessors.oas3 && !pluginModule.preprocessors.oas2) {
           throw new Error(
             `Plugin \`preprocessors\` must have \`oas3\` or \`oas2\` preprocessors "${p}.`,
           );
         }
-        if (plugin.preprocessors.oas3) {
-          plugin.preprocessors.oas3 = prefixRules(plugin.preprocessors.oas3, id);
+        plugin.preprocessors = {};
+        if (pluginModule.preprocessors.oas3) {
+          plugin.preprocessors.oas3 = prefixRules(pluginModule.preprocessors.oas3, id);
         }
-        if (plugin.preprocessors.oas2) {
-          plugin.preprocessors.oas2 = prefixRules(plugin.preprocessors.oas2, id);
+        if (pluginModule.preprocessors.oas2) {
+          plugin.preprocessors.oas2 = prefixRules(pluginModule.preprocessors.oas2, id);
         }
       }
 
-      if (plugin.decorators) {
-        if (!plugin.decorators.oas3 && !plugin.decorators.oas2) {
+      if (pluginModule.decorators) {
+        if (!pluginModule.decorators.oas3 && !pluginModule.decorators.oas2) {
           throw new Error(`Plugin \`decorators\` must have \`oas3\` or \`oas2\` decorators "${p}.`);
         }
-        if (plugin.decorators.oas3) {
-          plugin.decorators.oas3 = prefixRules(plugin.decorators.oas3, id);
+        plugin.decorators = {};
+        if (pluginModule.decorators.oas3) {
+          plugin.decorators.oas3 = prefixRules(pluginModule.decorators.oas3, id);
         }
-        if (plugin.decorators.oas2) {
-          plugin.decorators.oas2 = prefixRules(plugin.decorators.oas2, id);
+        if (pluginModule.decorators.oas2) {
+          plugin.decorators.oas2 = prefixRules(pluginModule.decorators.oas2, id);
         }
       }
 


### PR DESCRIPTION
## What/Why/How?

Clone plugin structures that are being changed while importing.

`loadConfig()` can be called more than once, which results in preprocessors, rules and  decorator rules in plugins being prefixed with the plugin id more than once.

This happens when running `openapi preview-docs` and then changing the config file, for example.

## Reference

This fixes #287.

## Testing

I've included a test that demonstrates the issue, as a separate commit. Without the other commit in this PR, the test fails with:

```
 FAIL  packages/core/src/config/__tests__/resolve-plugins.test.ts
  ● resolving a plugin › should prefix preprocessor names with the plugin id

    expect(received).toHaveProperty(path)

    Expected path: "test-plugin/description-preprocessor"
    Received path: []

    Received value: {"test-plugin/test-plugin/description-preprocessor": [Function description-preprocessor]}

      17 |     const plugin = config.lint.plugins[0];
      18 |
    > 19 |     expect(plugin.preprocessors?.oas2).toHaveProperty('test-plugin/description-preprocessor');
         |                                        ^
      20 |   });
      21 |
      22 |   it('should prefix decorator names with the plugin id', async () => {

      at packages/core/src/config/__tests__/resolve-plugins.test.ts:19:40
      at fulfilled (packages/core/src/config/__tests__/resolve-plugins.test.ts:5:58)

  ● resolving a plugin › should prefix decorator names with the plugin id

    expect(received).toHaveProperty(path)

    Expected path: "test-plugin/inject-x-stats"
    Received path: []

    Received value: {"test-plugin/test-plugin/test-plugin/inject-x-stats": [Function inject-x-stats]}

      24 |     const plugin = config.lint.plugins[0];
      25 |
    > 26 |     expect(plugin.decorators?.oas3).toHaveProperty('test-plugin/inject-x-stats');
         |                                     ^
      27 |   });
      28 | });
      29 |

      at packages/core/src/config/__tests__/resolve-plugins.test.ts:26:37
      at fulfilled (packages/core/src/config/__tests__/resolve-plugins.test.ts:5:58)
```

(exact output can vary depending on test execution order).

## Check yourself

- [X] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [X] All new/updated code is covered with tests

I didn't think this change affects workflows.

