### PR TITLE
fix: do not overwrite 'x-displayName' of a tag on join

### DIFF
--- a/packages/cli/src/commands/join.ts
+++ b/packages/cli/src/commands/join.ts
@@ -147,7 +147,7 @@ packageVersion: string
         tag.description = addComponentsPrefix(tag.description, componentsPrefix!);
       }
       if (!joinedDef.tags.find((t: any) => t.name === entrypointTagName)) {
-        tag['x-displayName'] = tag.name;
+        tag['x-displayName'] = tag['x-displayName'] || tag.name;
         tag.name = entrypointTagName;
         joinedDef.tags.push(tag);
       }


### PR DESCRIPTION
## What
When tags already specify `x-displayName`, setting it with the tag's name will probably result in setting a machine-readable value instead of the intended display name.

### Example
When joining documents that have `x-displayName` defined, it takes the `name` property of the tag regardless:

Source document:
```yaml
tags:
  - name: authentication
    x-displayName: Authentication
    description: Endpoints dealing with user authentication.
```

Resulting document:
```yaml
tags:
  - name: accounts_authentication
    x-displayName: authentication
    description: Endpoints dealing with user authentication.
```

Expected result:
```yaml
tags:
  - name: accounts_authentication
    x-displayName: Authentication
    description: Endpoints dealing with user authentication.
```

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests
