### PR TITLE
chore: update yargs version from rc to stable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9882,13 +9882,13 @@
         "handlebars": "^4.7.6",
         "portfinder": "^1.0.26",
         "simple-websocket": "^9.0.0",
-        "yargs": "17.0.0-candidate.6"
+        "yargs": "17.0.1"
       },
       "bin": {
         "openapi": "bin/cli.js"
       },
       "devDependencies": {
-        "@types/yargs": "^16.0.0",
+        "@types/yargs": "16.0.2",
         "typescript": "^4.0.3"
       },
       "engines": {
@@ -9896,9 +9896,9 @@
       }
     },
     "packages/cli/node_modules/@types/yargs": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.1.tgz",
-      "integrity": "sha512-x4HABGLyzr5hKUzBC9dvjciOTm11WVH1NWonNjGgxapnTHu5SWUqyqn0zQ6Re0yQU0lsQ6ztLCoMAKDGZflyxA==",
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.2.tgz",
+      "integrity": "sha512-EkZDJvHXblOE2/iFZb3Ty5c8RHPssmFvrXqj3V/ZLXtOt0f7xJh9Fd7p1pl2ITrNHM7Rl3Db3JJVBT7q/C0wUg==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -9939,9 +9939,9 @@
       }
     },
     "packages/cli/node_modules/yargs": {
-      "version": "17.0.0-candidate.6",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.0-candidate.6.tgz",
-      "integrity": "sha512-QL4bMmBh/zM0OMDkW0vF8xi4lQv4SPcoGraBLJfABMyp//i0z+/ZfDF4UWZYBUyK53BGhQ1r14u4PFtfRnW9SA==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz",
+      "integrity": "sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==",
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -9952,7 +9952,7 @@
         "yargs-parser": "^20.2.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "packages/core": {
@@ -10647,7 +10647,7 @@
       "requires": {
         "@redocly/openapi-core": "^1.0.0-beta.46",
         "@types/node": "^14.11.8",
-        "@types/yargs": "^16.0.0",
+        "@types/yargs": "16.0.2",
         "assert-node-version": "^1.0.3",
         "chokidar": "^3.4.0",
         "colorette": "^1.2.0",
@@ -10657,13 +10657,13 @@
         "portfinder": "^1.0.26",
         "simple-websocket": "^9.0.0",
         "typescript": "^4.0.3",
-        "yargs": "17.0.0-candidate.6"
+        "yargs": "17.0.1"
       },
       "dependencies": {
         "@types/yargs": {
-          "version": "16.0.1",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.1.tgz",
-          "integrity": "sha512-x4HABGLyzr5hKUzBC9dvjciOTm11WVH1NWonNjGgxapnTHu5SWUqyqn0zQ6Re0yQU0lsQ6ztLCoMAKDGZflyxA==",
+          "version": "16.0.2",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.2.tgz",
+          "integrity": "sha512-EkZDJvHXblOE2/iFZb3Ty5c8RHPssmFvrXqj3V/ZLXtOt0f7xJh9Fd7p1pl2ITrNHM7Rl3Db3JJVBT7q/C0wUg==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -10695,9 +10695,9 @@
           "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
         },
         "yargs": {
-          "version": "17.0.0-candidate.6",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.0-candidate.6.tgz",
-          "integrity": "sha512-QL4bMmBh/zM0OMDkW0vF8xi4lQv4SPcoGraBLJfABMyp//i0z+/ZfDF4UWZYBUyK53BGhQ1r14u4PFtfRnW9SA==",
+          "version": "17.0.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz",
+          "integrity": "sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==",
           "requires": {
             "cliui": "^7.0.2",
             "escalade": "^3.1.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,10 +44,10 @@
     "handlebars": "^4.7.6",
     "portfinder": "^1.0.26",
     "simple-websocket": "^9.0.0",
-    "yargs": "17.0.0-candidate.6"
+    "yargs": "17.0.1"
   },
   "devDependencies": {
-    "@types/yargs": "^16.0.0",
+    "@types/yargs": "16.0.2",
     "typescript": "^4.0.3"
   }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -237,17 +237,6 @@ yargs
       }),
     async (argv) => { previewDocs(argv) },
   )
-  // TODO: remove ts-ignore
-  // @ts-ignore: Until @types/yargs@17.0.0 is released
-  .completion('completion', 'Generate completion script.', (current, argv, completionFilter, done) => {
-  // @ts-ignore: Until @types/yargs@17.0.0 is released
-    completionFilter((err, completions) => {
-      if (err || argv._[1] === 'completion') {
-        done([]);
-      } else {
-        done(completions);
-      }
-    });
-  })
+  .completion('completion', 'Generate completion script.')
   .demandCommand(1)
   .strict().argv;


### PR DESCRIPTION
## What/Why/How?
We were using `yargs@17.0.0-candidate.6` for completion feature. Now that stable `yargs@17.0.1` is released, it's time to update.
## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests
