### PR TITLE
fix: utils.dumpBundle testing mock

### DIFF
--- a/packages/cli/src/__mocks__/utils.ts
+++ b/packages/cli/src/__mocks__/utils.ts
@@ -1,6 +1,6 @@
 export const getFallbackEntryPointsOrExit = jest.fn((entrypoints) => entrypoints.map(() => ''));
 export const getTotals = jest.fn(() => ({ errors: 0 }));
-export const dumpBundle = jest.fn();
+export const dumpBundle = jest.fn(() => '');
 export const slash = jest.fn();
 export const pluralize = jest.fn();
 export const getExecutionTime = jest.fn();


### PR DESCRIPTION
## What/Why/How?
Tests failing due to bad `utils.dumpBundle` mock return value type

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests
