### PR TITLE
Support OAS 3.1 in type extensions

### DIFF
--- a/packages/core/__tests__/walk.test.ts
+++ b/packages/core/__tests__/walk.test.ts
@@ -1,4 +1,5 @@
 import outdent from 'outdent';
+import each from 'jest-each';
 import * as path from 'path';
 
 import { lintDocument } from '../src/lint';
@@ -1246,7 +1247,10 @@ describe('context.resolve', () => {
 });
 
 describe('type extensions', () => {
-  it('should correctly visit extended types', async () => {
+  each([
+    ['3.0.0', 'oas3_0'],
+    ['3.1.0', 'oas3_1'],
+  ]).it('should correctly visit OpenAPI %s extended types', async (openapi, oas) => {
     const calls: string[] = [];
 
     const testRuleSet: Oas3RuleSet = {
@@ -1274,7 +1278,7 @@ describe('type extensions', () => {
 
     const document = parseYamlToDocument(
       outdent`
-        openapi: 3.0.0
+        openapi: ${openapi}
         x-webhooks:
           name: test
           parameters:
@@ -1289,7 +1293,7 @@ describe('type extensions', () => {
       config: makeConfigForRuleset(testRuleSet, {
         typeExtension: {
           oas3(types, version) {
-            expect(version).toEqual('oas3_0');
+            expect(version).toEqual(oas);
 
             return {
               ...types,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -251,6 +251,7 @@ export class LintConfig {
       if (plugin.typeExtension !== undefined) {
         switch (version) {
           case OasVersion.Version3_0:
+          case OasVersion.Version3_1:
             if (!plugin.typeExtension.oas3) continue;
             extendedTypes = plugin.typeExtension.oas3(extendedTypes, version);
           case OasVersion.Version2:


### PR DESCRIPTION
## What/Why/How?

Plugin type extensions are the only remaining place that doesn't support
OpenAPI 3.1.0 documents.

## Reference

Fixes #314

## Testing

I've parametrized the existing type extensions test. The fact that the test
adds webhook support (something OAS 3.1 has explicit support for now) may be
slightly silly, but the test is no less valid for it.

## Check yourself

- [X] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
  - (I don't think this is applicable here)
- [X] All new/updated code is covered with tests
