### PR TITLE
chore: additional exports for vs code extension

### DIFF
--- a/packages/core/src/format/codeframes.ts
+++ b/packages/core/src/format/codeframes.ts
@@ -173,7 +173,7 @@ function positionsToLoc(
   return { start, end };
 }
 
-function getAstNodeByPointer(root: YAMLNode, pointer: string, reportOnKey: boolean) {
+export function getAstNodeByPointer(root: YAMLNode, pointer: string, reportOnKey: boolean) {
   const pointerSegments = parsePointer(pointer);
   if (root === undefined) {
     return undefined;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,8 +1,16 @@
-export type { BundleOutputFormat } from './utils';
+export { BundleOutputFormat, readFileFromUrl } from './utils';
 export { Oas3_1Types } from './types/oas3_1';
 export { Oas3Types } from './types/oas3';
 export { Oas2Types } from './types/oas2';
-export { Oas3Definition, Oas3Components, Oas3PathItem, Oas3Paths, Oas3ComponentName, Oas3Schema, Oas3Tag } from './typings/openapi';
+export {
+  Oas3Definition,
+  Oas3Components,
+  Oas3PathItem,
+  Oas3Paths,
+  Oas3ComponentName,
+  Oas3Schema,
+  Oas3Tag,
+} from './typings/openapi';
 export { Oas2Definition } from './typings/swagger';
 export { StatsAccumulator, StatsName } from './typings/common';
 export { normalizeTypes } from './types';
@@ -11,12 +19,29 @@ export { Stats } from './rules/other/stats';
 export { Config, LintConfig, RawConfig, IGNORE_FILE } from './config/config';
 export { loadConfig } from './config/load';
 export { RedoclyClient } from './redocly';
-export { Source, BaseResolver, Document, resolveDocument, ResolveError, YamlParseError } from './resolve';
+export {
+  Source,
+  BaseResolver,
+  Document,
+  resolveDocument,
+  ResolveError,
+  YamlParseError,
+  makeDocumentFromString,
+} from './resolve';
 export { unescapePointer } from './ref-utils';
 export { detectOpenAPI, OasMajorVersion, openAPIMajor, OasVersion } from './oas-types';
 export { normalizeVisitors } from './visitors';
-export { WalkContext, walkDocument, NormalizedProblem, ProblemSeverity, LineColLocationObject, LocationObject, Loc } from './walk';
+export {
+  WalkContext,
+  walkDocument,
+  NormalizedProblem,
+  ProblemSeverity,
+  LineColLocationObject,
+  LocationObject,
+  Loc,
+} from './walk';
 
+export { getAstNodeByPointer, getLineColLocation } from './format/codeframes';
 export { formatProblems, OutputFormat, getTotals, Totals } from './format/format';
 export { lint, lint as validate, lintDocument, lintFromString } from './lint';
 export { bundle } from './bundle';


### PR DESCRIPTION
## What/Why/How?
[VS Code extension](https://github.com/Redocly/openapi-vs-code) requires exports of some additional functions

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
