### PR TITLE
feat: return type of reference in bundleDocument

### DIFF
--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -80,6 +80,7 @@ export async function bundleDocument(opts: {
   const ctx: BundleContext = {
     problems: [],
     oasVersion: oasVersion,
+    refTypes: new Map(),
   };
 
   const bundleVisitor = normalizeVisitors(
@@ -113,6 +114,7 @@ export async function bundleDocument(opts: {
     bundle: document,
     problems: ctx.problems.map((problem) => config.addProblemToIgnore(problem)),
     fileDependencies: externalRefResolver.getFiles(),
+    refTypes: ctx.refTypes,
   };
 }
 

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -80,7 +80,7 @@ export async function bundleDocument(opts: {
   const ctx: BundleContext = {
     problems: [],
     oasVersion: oasVersion,
-    refTypes: new Map(),
+    refTypes: new Map<string, NormalizedNodeType>(),
   };
 
   const bundleVisitor = normalizeVisitors(

--- a/packages/core/src/walk.ts
+++ b/packages/core/src/walk.ts
@@ -77,6 +77,7 @@ export type NormalizedProblem = {
 export type WalkContext = {
   problems: NormalizedProblem[];
   oasVersion: OasVersion;
+  refTypes?: Map<string, NormalizedNodeType>;
 };
 
 function collectParents(ctx: VisitorLevelContext) {
@@ -143,6 +144,9 @@ export function walkDocument<T>(opts: {
             },
             { node: resolvedNode, location: resolvedLocation, error },
           );
+          if (resolvedLocation?.source.absoluteRef && ctx.refTypes) {
+            ctx.refTypes.set(resolvedLocation?.source.absoluteRef, type);
+          }
         }
       }
     }


### PR DESCRIPTION
## What/Why/How?
on vs code extension, we need the types of file reference.  We use it in the autocomplete.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
