### PR TITLE
docs: OpenAPI CLI commands home page

### DIFF
--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -22,8 +22,10 @@ To define the behavior of the commands, you can use configuration files:
 
 For more information, refer to the [configuration section](../configuration/index.mdx).
 
-:::warning
-The CLI tool looks for configuration files in the current working directory. If it detects them, it will use the options set in those configuration files for the commands. Learn more about the [configuration file structure and options](../configuration/index.mdx).
+:::attention Note
+
+The CLI tool looks for configuration files in the current working directory. If it detects them, it will use the options set in those configuration files for the commands. Learn more about the [configuration file structure and options](../configuration/configuration-file.mdx).
 
 When executing any of the commands, you can override the default configuration file by providing a path to another configuration file with the `--config` option.
+
 :::

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -5,22 +5,15 @@ tocMaxDepth: 2
 
 Redocly OpenAPI CLI currently supports the following commands:
 
-- [bundle](bundle.md)
-- [join](join.md)
-- [lint](lint.md)
-- [login](login.md)
-- [logout](logout.md)
-- [preview-docs](preview-docs.md)
-- [push](push.md)
-- [split](split.md)
-- [stats](stats.md)
+commands            |                                 | 
+--------------------|---------------------------------|------------------
+[bundle](bundle.md) | [split](split.md)               | [join](join.md)
+[lint](lint.md)     | [preview-docs](preview-docs.md) |  [stats](stats.md)
+[login](login.md)   | [logout](logout.md)             | [push](push.md)
 
+To define the behavior of the commands, you can use configuration files:
 
-The following configuration files define the behavior of the CLI tool:
+- `.redocly.yaml` - define the location of your root files, linting rules, and reference docs configuration information.
+- `.redocly.lint-ignore.yaml` - ignore specific lint messages.
 
-- `.redocly.yaml` - used to define the location of your root files, linting rules, and reference docs configuration information.
-- `.redocly.lint-ignore.yaml` - used to ignore specific lint messages.
-
-The CLI tool looks for configuration files in the current working directory. If it detects them, it will use the options set in those configuration files for the commands. Learn more about the [configuration file structure and options](../configuration/index.mdx).
-
-When executing any of the commands, you can override the default configuration file by providing a path to another configuration file with the `--config` option.
+For more information about configuration, please refer to the [corresponding](#) section.

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -20,4 +20,10 @@ To define the behavior of the commands, you can use configuration files:
 - `.redocly.yaml` - define the location of your root files, linting rules, and reference docs configuration information.
 - `.redocly.lint-ignore.yaml` - ignore specific lint messages.
 
-For more information about configuration, please refer to the [corresponding](../configuration/index.mdx) section.
+For more information, refer to the [configuration section](../configuration/index.mdx).
+
+:::warning
+The CLI tool looks for configuration files in the current working directory. If it detects them, it will use the options set in those configuration files for the commands. Learn more about the [configuration file structure and options](../configuration/index.mdx).
+
+When executing any of the commands, you can override the default configuration file by providing a path to another configuration file with the `--config` option.
+:::

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -5,11 +5,15 @@ tocMaxDepth: 2
 
 Redocly OpenAPI CLI currently supports the following commands:
 
-commands            |                                 | 
---------------------|---------------------------------|------------------
-[bundle](bundle.md) | [split](split.md)               | [join](join.md)
-[lint](lint.md)     | [preview-docs](preview-docs.md) |  [stats](stats.md)
-[login](login.md)   | [logout](logout.md)             | [push](push.md)
+* [bundle](bundle.md)
+* [join](join.md)
+* [lint](lint.md) 
+* [login](login.md)
+* [logout](logout.md)
+* [preview-docs](preview-docs.md)
+* [push](push.md)
+* [split](split.md)
+* [stats](stats.md)
 
 To define the behavior of the commands, you can use configuration files:
 

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -16,4 +16,4 @@ To define the behavior of the commands, you can use configuration files:
 - `.redocly.yaml` - define the location of your root files, linting rules, and reference docs configuration information.
 - `.redocly.lint-ignore.yaml` - ignore specific lint messages.
 
-For more information about configuration, please refer to the [corresponding](#) section.
+For more information about configuration, please refer to the [corresponding](../configuration/index.mdx) section.


### PR DESCRIPTION
## What/Why/How?

Removed redundancy from the OpenAPI CLI commands home page. Made the page more concise.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
