### PR TITLE
Strip query parameters from request URL in preview server

### DIFF
--- a/packages/cli/src/__tests__/utils.test.ts
+++ b/packages/cli/src/__tests__/utils.test.ts
@@ -1,4 +1,7 @@
-import { slash } from '../utils';
+import { isSubdir, slash } from '../utils';
+
+jest.mock("os");
+
 
 describe('slash path', () => {
   it('can correctly slash path', () => {
@@ -16,4 +19,43 @@ describe('slash path', () => {
     const extended = '\\\\?\\some\\path';
     expect(slash(extended)).toBe(extended);
   });
+});
+
+describe('isSubdir', () => {
+  it('can correctly determine if subdir', () => {
+    (
+      [
+        ['/foo', '/foo', false],
+        ['/foo', '/bar', false],
+        ['/foo', '/foobar', false],
+        ['/foo', '/foo/bar', true],
+        ['/foo', '/foo/../bar', false],
+        ['/foo', '/foo/./bar', true],
+        ['/bar/../foo', '/foo/bar', true],
+        ['/foo', './bar', false],
+        ['/foo', '/foo/..bar', true],
+      ] as [string, string, boolean][]
+    ).forEach(([parent, child, expectRes]) => {
+      expect(isSubdir(parent, child)).toBe(expectRes);
+    });
+  });
+
+  it('can correctly determine if subdir for windows-based paths', () => {
+    const os = require('os');
+    os.platform.mockImplementation(() => 'win32');
+
+    (
+      [
+        ['C:/Foo', 'C:/Foo/Bar', true],
+        ['C:\\Foo', 'C:\\Bar', false],
+        ['C:\\Foo', 'D:\\Foo\\Bar', false],
+      ] as [string, string, boolean][]
+    ).forEach(([parent, child, expectRes]) => {
+      expect(isSubdir(parent, child)).toBe(expectRes);
+    });
+  });
+
+  afterEach(() => {
+    jest.resetModules()
+  })
 });

--- a/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
+++ b/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 
 import { startHttpServer, startWsServer, respondWithGzip, mimeTypes } from './server';
 import type { IncomingMessage } from 'http';
+import { isSubdir } from 'cli/src/utils';
 
 function getPageHTML(
   htmlTemplate: string,
@@ -104,6 +105,12 @@ export default async function startPreviewServer(
           '/simplewebsocket.min.js': require.resolve('simple-websocket/simplewebsocket.min.js'),
         }[url || ''] ||
         path.resolve(htmlTemplate ? path.dirname(htmlTemplate) : process.cwd(), `.${url}`);
+
+      if (!isSubdir(process.cwd(), filePath)) {
+        respondWithGzip('404 Not Found', request, response, { 'Content-Type': 'text/html' }, 404);
+        console.timeEnd(colorette.dim(`GET ${request.url}`));
+        return;
+      }
 
       const extname = String(path.extname(filePath)).toLowerCase() as keyof typeof mimeTypes;
 

--- a/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
+++ b/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
@@ -60,10 +60,11 @@ export default async function startPreviewServer(
 ) {
   const defaultTemplate = path.join(__dirname, 'default.hbs');
   const handler = async (request: IncomingMessage, response: any) => {
-    console.time(colorette.dim(`GET ${request.url}`));
+    const url = request.url.split('?')[0];
+    console.time(colorette.dim(`GET ${url}`));
     const { htmlTemplate } = getOptions() || {};
 
-    if (request.url === '/') {
+    if (url === '/') {
       respondWithGzip(
         getPageHTML(htmlTemplate || defaultTemplate, getOptions(), useRedocPro, wsPort),
         request,
@@ -72,7 +73,7 @@ export default async function startPreviewServer(
           'Content-Type': 'text/html',
         },
       );
-    } else if (request.url === '/openapi.json') {
+    } else if (url === '/openapi.json') {
       const bundle = await getBundle();
       if (bundle === undefined) {
         respondWithGzip(
@@ -101,8 +102,8 @@ export default async function startPreviewServer(
         {
           '/hot.js': path.join(__dirname, 'hot.js'),
           '/simplewebsocket.min.js': require.resolve('simple-websocket/simplewebsocket.min.js'),
-        }[request.url || ''] ||
-        path.resolve(htmlTemplate ? path.dirname(htmlTemplate) : process.cwd(), `.${request.url}`);
+        }[url || ''] ||
+        path.resolve(htmlTemplate ? path.dirname(htmlTemplate) : process.cwd(), `.${url}`);
 
       const extname = String(path.extname(filePath)).toLowerCase() as keyof typeof mimeTypes;
 
@@ -125,7 +126,7 @@ export default async function startPreviewServer(
         }
       }
     }
-    console.timeEnd(colorette.dim(`GET ${request.url}`));
+    console.timeEnd(colorette.dim(`GET ${url}`));
   };
 
   let wsPort = await portfinder.getPortPromise({ port: 32201 });

--- a/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
+++ b/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
@@ -61,11 +61,10 @@ export default async function startPreviewServer(
 ) {
   const defaultTemplate = path.join(__dirname, 'default.hbs');
   const handler = async (request: IncomingMessage, response: any) => {
-    const url = request.url.split('?')[0];
-    console.time(colorette.dim(`GET ${url}`));
+    console.time(colorette.dim(`GET ${request.url}`));
     const { htmlTemplate } = getOptions() || {};
 
-    if (url === '/') {
+    if (request.url === '/') {
       respondWithGzip(
         getPageHTML(htmlTemplate || defaultTemplate, getOptions(), useRedocPro, wsPort),
         request,
@@ -74,7 +73,7 @@ export default async function startPreviewServer(
           'Content-Type': 'text/html',
         },
       );
-    } else if (url === '/openapi.json') {
+    } else if (request.url === '/openapi.json') {
       const bundle = await getBundle();
       if (bundle === undefined) {
         respondWithGzip(
@@ -103,8 +102,8 @@ export default async function startPreviewServer(
         {
           '/hot.js': path.join(__dirname, 'hot.js'),
           '/simplewebsocket.min.js': require.resolve('simple-websocket/simplewebsocket.min.js'),
-        }[url || ''] ||
-        path.resolve(htmlTemplate ? path.dirname(htmlTemplate) : process.cwd(), `.${url}`);
+        }[request.url || ''] ||
+        path.resolve(htmlTemplate ? path.dirname(htmlTemplate) : process.cwd(), `.${request.url}`);
 
       if (!isSubdir(process.cwd(), filePath)) {
         respondWithGzip('404 Not Found', request, response, { 'Content-Type': 'text/html' }, 404);
@@ -133,7 +132,7 @@ export default async function startPreviewServer(
         }
       }
     }
-    console.timeEnd(colorette.dim(`GET ${url}`));
+    console.timeEnd(colorette.dim(`GET ${request.url}`));
   };
 
   let wsPort = await portfinder.getPortPromise({ port: 32201 });

--- a/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
+++ b/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 
 import { startHttpServer, startWsServer, respondWithGzip, mimeTypes } from './server';
 import type { IncomingMessage } from 'http';
-import { isSubdir } from 'cli/src/utils';
+import { isSubdir } from '../../../utils';
 
 function getPageHTML(
   htmlTemplate: string,

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -291,3 +291,11 @@ export function slash(path: string): string {
 
   return path.replace(/\\/g, '/');
 }
+
+/**
+ * Checks if dir is subdir of parent
+ */
+export function isSubdir(parent: string, dir: string): boolean {
+  const relative = path.relative(parent, dir);
+  return !!relative && !/^..($|\/)/.test(relative) && !path.isAbsolute(relative);
+}


### PR DESCRIPTION
## What/Why/How?

The file `packages/cli/src/commands/preview-docs/preview-server/preview-server.ts` contains a security defect that allows directory traversal of the complete file path on a server and the download of files via query parameters on the request URI.

Example: 

http://localhost:8080/jsp/help-sb-download.jsp?sbFileName=../../../../.redocly.yaml

Applying a `request.url.split('?')[0]` at the start of the preview server function has stopped this from occurring.

## Reference

https://github.com/Redocly/openapi-cli/blob/master/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts#L99

The usage of `path.resolve()` on this line can result in arbitrary download of any file on the server if query params are exploited.

## Testing

Fix tested manually

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
