### PR TITLE
build: fix preview-docs command in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+*
+!package.json
+!tsconfig.build.json
+!tsconfig.json
+!package-lock.json
+!packages/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,26 @@ FROM node:alpine
 
 WORKDIR /build
 
-COPY tsconfig.json tsconfig.build.json /build/
+# Copy files required for npm install only
 COPY package.json package-lock.json /build/
-COPY packages /build/packages
+COPY packages/cli/package.json /build/packages/cli/
+COPY packages/core/package.json   /build/packages/core/
+COPY packages/cli/bin/ /build/packages/cli/bin/
 
-RUN npm ci --no-optional
+RUN npm ci --no-optional --ignore-scripts
+
+# Copy rest of the files
+COPY . /build/
+RUN npm run prepare
 
 # Install openapi-cli globally, similar to npm install --global @redocly/openapi-cli
 # but the local package is used here
 RUN mv -- "$(npm pack packages/cli/)" redocly-openapi-cli.tgz && \
-	npm install --global redocly-openapi-cli.tgz
+	  npm install --global redocly-openapi-cli.tgz
 
 # npm pack in the previous RUN command does not include these assets
 RUN cp packages/cli/src/commands/preview-docs/preview-server/default.hbs /usr/local/lib/node_modules/@redocly/openapi-cli/lib/commands/preview-docs/preview-server/default.hbs && \
-	cp packages/cli/src/commands/preview-docs/preview-server/hot.js /usr/local/lib/node_modules/@redocly/openapi-cli/lib/commands/preview-docs/preview-server/hot.js
+	  cp packages/cli/src/commands/preview-docs/preview-server/hot.js /usr/local/lib/node_modules/@redocly/openapi-cli/lib/commands/preview-docs/preview-server/hot.js
 
 # Clean up to reduce image size
 RUN npm cache clean --force && rm -rf /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,24 @@ FROM node:alpine
 
 WORKDIR /build
 
-COPY webpack.config.ts tsconfig.json tsconfig.build.json /build/
+COPY tsconfig.json tsconfig.build.json /build/
 COPY package.json package-lock.json /build/
 COPY packages /build/packages
 
 RUN npm ci --no-optional
-RUN npm run webpack-bundle
 
-FROM node:alpine
+# Install openapi-cli globally, similar to npm install --global @redocly/openapi-cli
+# but the local package is used here
+RUN mv -- "$(npm pack packages/cli/)" redocly-openapi-cli.tgz && \
+	npm install --global redocly-openapi-cli.tgz
+
+# npm pack in the previous RUN command does not include these assets
+RUN cp packages/cli/src/commands/preview-docs/preview-server/default.hbs /usr/local/lib/node_modules/@redocly/openapi-cli/lib/commands/preview-docs/preview-server/default.hbs && \
+	cp packages/cli/src/commands/preview-docs/preview-server/hot.js /usr/local/lib/node_modules/@redocly/openapi-cli/lib/commands/preview-docs/preview-server/hot.js
+
+# Clean up to reduce image size
+RUN npm cache clean --force && rm -rf /build
 
 WORKDIR /spec
-COPY --from=0 /build/dist/bundle.js /bin/openapi-cli
 
-ENTRYPOINT [ "node", "/bin/openapi-cli"]
+ENTRYPOINT [ "openapi" ]


### PR DESCRIPTION
## What/Why/How?

As described in #272, running `preview-docs` in a `redocly/openapi-cli` Docker container will cause the container to crash instantly. This is not an issue with the Docker image. The problem lies in the Webpack build process that is causing the following `TypeError`. 

Running the following command `npm run bundle && node dist/bundle.js preview-docs resources/pets.yaml` will result in the following error as well.

```
TypeError: s is not a constructor
    at Object.t.startWsServer (/bin/openapi-cli:49:129227)
    at Object.<anonymous> (/bin/openapi-cli:49:21717)
    at Generator.next (<anonymous>)
    at o (/bin/openapi-cli:49:19069)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

---
Currently Webpack will load `simple-websocket` as an empty module. This is introduced in PR #177, which was merged into the `master` branch before the Dockerfile was first created in commit ceaa205497a6cee6a02876a75b8ddcd4e37aa23c. 
https://github.com/Redocly/openapi-cli/blob/360c865d23668c46cad9ee63677fce54925ce238/webpack.config.ts#L20-L26

---
However, `preview-docs` requires the websocket server to be started. If `simple-websocket` is loaded as an empty module, then `SocketServer` will have the value `{}` and hence `new SocketServer` will throw a `TypeError`.

https://github.com/Redocly/openapi-cli/blob/38139e51393d7589217362986b36fb48771ab703/packages/cli/src/commands/preview-docs/preview-server/server.ts#L5

https://github.com/Redocly/openapi-cli/blob/38139e51393d7589217362986b36fb48771ab703/packages/cli/src/commands/preview-docs/preview-server/server.ts#L65-L66

---

To fix this, we would need to configure Webpack to load `simple-websocket`. The steps are:

1. Use `babel-loader` to load the `simple-websocket` module. We will need to use the `@babel/plugin-proposal-class-properties` plugin as well, otherwise the following error will occur.
```
ERROR in ./node_modules/simple-websocket/server.js 45:19
Module parse failed: Unexpected token (45:19)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|   }
| 
>   _handleListening = () => {
|     this.emit('listening')
|   }
 @ ./packages/cli/src/commands/preview-docs/preview-server/server.ts 6:21-58
 @ ./packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
 @ ./packages/cli/src/commands/preview-docs/index.ts
 @ ./packages/cli/src/index.ts
```

2. Configure Webpack to use named instead of number for Module ID. `require.resolve` returns a number instead of a string by Webpack for optimization purposes (see [Webpack 4 require.resolve](https://v4.webpack.js.org/api/module-methods/#requireresolve) and [Webpack 4 Module IDs](https://v4.webpack.js.org/configuration/optimization/#optimizationmoduleids)). This is required otherwise line 107 will fail because `filePath` is a number, and `path.extname` expects a string.
https://github.com/Redocly/openapi-cli/blob/38139e51393d7589217362986b36fb48771ab703/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts#L99-L107

3. Copy the `packages/cli/src/commands/preview-docs/preview-server/default.hbs` file into `dist` folder, and include it into the Docker image too.

## Reference

This pull request fixes Issue #272.

## Testing

## Screenshots (optional)

### Before
![before](https://user-images.githubusercontent.com/20135478/132394577-fb910ed1-44a8-4d16-8121-19a2d088fffa.png)

### After
![after](https://user-images.githubusercontent.com/20135478/132394704-a75125aa-61fd-48f4-8cdf-3e030fbed9d1.png)

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
