### PR TITLE
bumped ajv version to ^8.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -937,9 +937,9 @@
       }
     },
     "node_modules/@redocly/ajv": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.6.2.tgz",
-      "integrity": "sha512-tU8fQs0D76ZKhJ2cWtnfQthWqiZgGBx0gH0+5D8JvaBEBaqA8foPPBt3Nonwr3ygyv5xrw2IzKWgIY86BlGs+w==",
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.6.4.tgz",
+      "integrity": "sha512-y9qNj0//tZtWB2jfXNK3BX18BSBp9zNR7KE7lMysVHwbZtY392OJCjm6Rb/h4UHH2r1AqjNEHFD6bRn+DqU9Mw==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -10276,7 +10276,7 @@
       "version": "1.0.0-beta.65",
       "license": "MIT",
       "dependencies": {
-        "@redocly/ajv": "^8.6.2",
+        "@redocly/ajv": "^8.6.4",
         "@types/node": "^14.11.8",
         "colorette": "^1.2.0",
         "js-levenshtein": "^1.1.6",
@@ -11024,9 +11024,9 @@
       }
     },
     "@redocly/ajv": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.6.2.tgz",
-      "integrity": "sha512-tU8fQs0D76ZKhJ2cWtnfQthWqiZgGBx0gH0+5D8JvaBEBaqA8foPPBt3Nonwr3ygyv5xrw2IzKWgIY86BlGs+w==",
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.6.4.tgz",
+      "integrity": "sha512-y9qNj0//tZtWB2jfXNK3BX18BSBp9zNR7KE7lMysVHwbZtY392OJCjm6Rb/h4UHH2r1AqjNEHFD6bRn+DqU9Mw==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -11062,7 +11062,7 @@
     "@redocly/openapi-core": {
       "version": "file:packages/core",
       "requires": {
-        "@redocly/ajv": "^8.6.2",
+        "@redocly/ajv": "^8.6.4",
         "@types/js-levenshtein": "^1.1.0",
         "@types/js-yaml": "^4.0.3",
         "@types/lodash.isequal": "^4.5.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,7 @@
     "Andriy Leliv <andriy@redoc.ly> (https://redoc.ly/)"
   ],
   "dependencies": {
-    "@redocly/ajv": "^8.6.2",
+    "@redocly/ajv": "^8.6.4",
     "@types/node": "^14.11.8",
     "colorette": "^1.2.0",
     "js-levenshtein": "^1.1.6",


### PR DESCRIPTION
## What/Why/How?

@redocly/ajv: "^8.6.4"

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [x] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
