### PR TITLE
chore: made the dockerhub workflow a consequtive step after publishing

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - v[0-9]*.[0-9]*.[0-9]*
+      - v[0-9]+.[0-9]+.[0-9]+-[a-z]+.[0-9]+ # beta/rc releases
 
 jobs:
   test:
@@ -96,3 +97,6 @@ jobs:
       run: cd packages/core && npm publish && cd ../cli && npm publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  call-dockerhub:
+    needs: [publish]
+    uses: Redocly/openapi-cli/.github/workflows/dockerhub.yaml@master

--- a/.github/workflows/dockerhub.yaml
+++ b/.github/workflows/dockerhub.yaml
@@ -2,11 +2,7 @@
 
 name: CD to Docker Hub
 
-on:
-  push:
-    tags:
-      - v[0-9]+.[0-9]+.[0-9]+
-      - v[0-9]+.[0-9]+.[0-9]+-[a-z]+.[0-9]+ # beta/rc releases
+on: workflow_call
 
 jobs:
   docker:


### PR DESCRIPTION
## What/Why/How?

The **CD to Docker Hub** workflow often fails on the first run. 

**Possible reason:** a race condition with the **CD to NPM & AWS S3** workflow, deployment part:
In case `packages/cli/package.json` contains the just releasing version of the `@redocly/openapi-core` as dependency,
it tries to load it from npm before it is published. 
**Solution:** Make the **CD to Docker Hub** call as the last job of the **CD to NPM & AWS S3** workflow.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
