### PR TITLE
fix: inline dereferenced schema when original schema name matches resolved schema name

### DIFF
--- a/packages/core/__tests__/__snapshots__/bundle.test.ts.snap
+++ b/packages/core/__tests__/__snapshots__/bundle.test.ts.snap
@@ -99,3 +99,48 @@ components:
       name: shared-a
 
 `;
+
+exports[`bundle should place referenced schema inline referenced schema name resolves to original schema name 1`] = `
+openapi: 3.0.0
+info:
+  title: My API
+  description: It ain't so wonderful, but at least it's mine.
+  version: '1.0'
+  contact:
+    email: me@theintenet.com
+    name: me
+tags:
+  - name: tag1
+servers:
+  - url: https://dev01.internet.com/api/v0
+    description: Development server.
+components:
+  schemas:
+    vendor:
+      title: vendor
+      type: object
+      description: Vendors
+      properties:
+        key:
+          type: string
+          description: System-assigned key for the vendor.
+          readOnly: true
+        id:
+          type: string
+          description: >
+            Unique identifier of the vendor.
+
+            You must specify a unique vendor ID when creating a vendor unless
+            document sequencing is configured, in which case the ID is
+            auto-generated.
+        name:
+          type: string
+          description: Name of the vendor.
+        isOneTimeUse:
+          type: boolean
+          description: One-time use
+          default: false
+    myvendor:
+      $ref: '#/components/schemas/vendor'
+
+`;

--- a/packages/core/__tests__/__snapshots__/bundle.test.ts.snap
+++ b/packages/core/__tests__/__snapshots__/bundle.test.ts.snap
@@ -106,11 +106,14 @@ paths:
   /pet:
     post:
       requestBody:
-        $ref: '#/components/requestBodies/requestBody'
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/requestBody'
 components:
   schemas:
     requestBody:
-      content: &ref_0
+      content:
         application/json:
           schema:
             type: object
@@ -119,14 +122,11 @@ components:
                 type: string
               b:
                 type: number
-  requestBodies:
-    requestBody:
-      content: *ref_0
 
 `;
 
 exports[`bundle should place referenced schema inline when referenced schema name resolves to original schema name 1`] = `
-openapi: 3.0.0
+openapi: 3.1.0
 info:
   title: My API
   description: It ain't so wonderful, but at least it's mine.
@@ -134,11 +134,17 @@ info:
   contact:
     email: me@theintenet.com
     name: me
-tags:
-  - name: tag1
-servers:
-  - url: https://dev01.internet.com/api/v0
-    description: Development server.
+paths:
+  /test:
+    get:
+      summary: test
+      responses:
+        '200':
+          description: test
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/vendor'
 components:
   schemas:
     vendor:
@@ -167,5 +173,9 @@ components:
           default: false
     myvendor:
       $ref: '#/components/schemas/vendor'
+    simple:
+      type: string
+    A:
+      type: string
 
 `;

--- a/packages/core/__tests__/__snapshots__/bundle.test.ts.snap
+++ b/packages/core/__tests__/__snapshots__/bundle.test.ts.snap
@@ -100,7 +100,32 @@ components:
 
 `;
 
-exports[`bundle should place referenced schema inline referenced schema name resolves to original schema name 1`] = `
+exports[`bundle should not place referened schema inline when component in question is not of type "schemas" 1`] = `
+openapi: 3.0.0
+paths:
+  /pet:
+    post:
+      requestBody:
+        $ref: '#/components/requestBodies/requestBody'
+components:
+  schemas:
+    requestBody:
+      content: &ref_0
+        application/json:
+          schema:
+            type: object
+            properties:
+              a:
+                type: string
+              b:
+                type: number
+  requestBodies:
+    requestBody:
+      content: *ref_0
+
+`;
+
+exports[`bundle should place referenced schema inline when referenced schema name resolves to original schema name 1`] = `
 openapi: 3.0.0
 info:
   title: My API

--- a/packages/core/__tests__/__snapshots__/bundle.test.ts.snap
+++ b/packages/core/__tests__/__snapshots__/bundle.test.ts.snap
@@ -177,5 +177,11 @@ components:
       type: string
     A:
       type: string
+    test:
+      $ref: '#/components/schemas/rename-2'
+    rename:
+      type: string
+    rename-2:
+      type: number
 
 `;

--- a/packages/core/__tests__/bundle.test.ts
+++ b/packages/core/__tests__/bundle.test.ts
@@ -78,7 +78,7 @@ describe('bundle', () => {
     expect(res.parsed).toMatchSnapshot();
   });
 
-  it('should place referenced schema inline referenced schema name resolves to original schema name', async () => {
+  it('should place referenced schema inline when referenced schema name resolves to original schema name', async () => {
     const { bundle: res, problems } = await bundle({
       config: new Config({}),
       ref: path.join(__dirname, 'fixtures/refs/externalref.yaml'),
@@ -87,4 +87,14 @@ describe('bundle', () => {
     expect(problems).toHaveLength(0);
     expect(res.parsed).toMatchSnapshot();
   });
+
+  it('should not place referened schema inline when component in question is not of type "schemas"', async () => {
+    const { bundle: res, problems } = await bundle({
+      config: new Config({}),
+      ref: path.join(__dirname, 'fixtures/refs/external-request-body.yaml'),
+    });
+
+    expect(problems).toHaveLength(0);
+    expect(res.parsed).toMatchSnapshot();
+  })
 });

--- a/packages/core/__tests__/bundle.test.ts
+++ b/packages/core/__tests__/bundle.test.ts
@@ -10,7 +10,7 @@ import { BaseResolver } from '../src/resolve';
 describe('bundle', () => {
   expect.addSnapshotSerializer(yamlSerializer);
 
-  const testDocument =  parseYamlToDocument(
+  const testDocument = parseYamlToDocument(
     outdent`
       openapi: 3.0.0
       paths:
@@ -72,6 +72,16 @@ describe('bundle', () => {
       config: new LintConfig({}),
       document: testDocument,
       dereference: true,
+    });
+
+    expect(problems).toHaveLength(0);
+    expect(res.parsed).toMatchSnapshot();
+  });
+
+  it('should place referenced schema inline referenced schema name resolves to original schema name', async () => {
+    const { bundle: res, problems } = await bundle({
+      config: new Config({}),
+      ref: path.join(__dirname, 'fixtures/refs/externalref.yaml'),
     });
 
     expect(problems).toHaveLength(0);

--- a/packages/core/__tests__/fixtures/refs/definitions.yaml
+++ b/packages/core/__tests__/fixtures/refs/definitions.yaml
@@ -1,0 +1,3 @@
+$defs:
+  A:
+    type: string

--- a/packages/core/__tests__/fixtures/refs/external-request-body.yaml
+++ b/packages/core/__tests__/fixtures/refs/external-request-body.yaml
@@ -3,8 +3,11 @@ paths:
   /pet:
     post:
       requestBody:
-        $ref: ./requestBody.yaml
-components: 
-  schemas: 
+        content:
+          application/json:
+            schema:
+              $ref: ./requestBody.yaml
+components:
+  schemas:
     requestBody:
       $ref: ./requestBody.yaml

--- a/packages/core/__tests__/fixtures/refs/external-request-body.yaml
+++ b/packages/core/__tests__/fixtures/refs/external-request-body.yaml
@@ -1,0 +1,10 @@
+openapi: 3.0.0
+paths:
+  /pet:
+    post:
+      requestBody:
+        $ref: ./requestBody.yaml
+components: 
+  schemas: 
+    requestBody:
+      $ref: ./requestBody.yaml

--- a/packages/core/__tests__/fixtures/refs/externalref.yaml
+++ b/packages/core/__tests__/fixtures/refs/externalref.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.0
+openapi: 3.1.0
 info:
   title: My API
   description: It ain't so wonderful, but at least it's mine.
@@ -6,15 +6,24 @@ info:
   contact:
     email: me@theintenet.com
     name: me
-tags:
-  - name: tag1
-servers:
-  - url: 'https://dev01.internet.com/api/v0'
-    description: Development server.
-
+paths:
+  /test:
+    get:
+      summary: 'test'
+      responses:
+        200:
+          description: test
+          content:
+            application/json:
+              schema:
+                $ref: ./vendor.schema.yaml
 components:
   schemas:
     vendor:
       $ref: ./vendor.schema.yaml
     myvendor:
       $ref: ./vendor.schema.yaml
+    simple:
+      $ref: ./simple.yaml
+    A:
+      $ref: ./definitions.yaml#/$defs/A

--- a/packages/core/__tests__/fixtures/refs/externalref.yaml
+++ b/packages/core/__tests__/fixtures/refs/externalref.yaml
@@ -27,3 +27,9 @@ components:
       $ref: ./simple.yaml
     A:
       $ref: ./definitions.yaml#/$defs/A
+    test:
+      $ref: ./rename.yaml
+    rename:
+      type: string
+    rename-2:
+      $ref: ./rename.yaml

--- a/packages/core/__tests__/fixtures/refs/externalref.yaml
+++ b/packages/core/__tests__/fixtures/refs/externalref.yaml
@@ -1,0 +1,20 @@
+openapi: 3.0.0
+info:
+  title: My API
+  description: It ain't so wonderful, but at least it's mine.
+  version: '1.0'
+  contact:
+    email: me@theintenet.com
+    name: me
+tags:
+  - name: tag1
+servers:
+  - url: 'https://dev01.internet.com/api/v0'
+    description: Development server.
+
+components:
+  schemas:
+    vendor:
+      $ref: ./vendor.schema.yaml
+    myvendor:
+      $ref: ./vendor.schema.yaml

--- a/packages/core/__tests__/fixtures/refs/rename.yaml
+++ b/packages/core/__tests__/fixtures/refs/rename.yaml
@@ -1,0 +1,1 @@
+type: number

--- a/packages/core/__tests__/fixtures/refs/requestBody.yaml
+++ b/packages/core/__tests__/fixtures/refs/requestBody.yaml
@@ -1,0 +1,9 @@
+content: 
+  application/json: 
+    schema: 
+      type: object
+      properties: 
+        a:
+          type: string
+        b:
+          type: number

--- a/packages/core/__tests__/fixtures/refs/simple.yaml
+++ b/packages/core/__tests__/fixtures/refs/simple.yaml
@@ -1,0 +1,1 @@
+type: string

--- a/packages/core/__tests__/fixtures/refs/vendor.schema.yaml
+++ b/packages/core/__tests__/fixtures/refs/vendor.schema.yaml
@@ -1,0 +1,20 @@
+title: vendor
+type: object
+description: Vendors
+properties:
+  key:
+    type: string
+    description: System-assigned key for the vendor.
+    readOnly: true
+  id:
+    type: string
+    description: |
+      Unique identifier of the vendor.
+      You must specify a unique vendor ID when creating a vendor unless document sequencing is configured, in which case the ID is auto-generated.
+  name:
+    type: string
+    description: Name of the vendor.
+  isOneTimeUse:
+    type: boolean
+    description: One-time use
+    default: false

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -187,10 +187,11 @@ function makeBundleVisitor(version: OasMajorVersion, dereference: boolean, rootD
         if (!componentType) {
           replaceRef(node, resolved, ctx);
         } else {
-          if (resolved.node.title === ctx.key && componentType === 'schemas') {
+          if (shouldPlaceSchemaReferenceInline(componentType, resolved, ctx)) {
             // if the schema name matches referenced file name we will
             // just inline referenced schema
-            // w/o producing new schema name like (customer-2)
+            // w/o producing new name like (customer-2)
+            // this rule works only for componentType === 'schemas'
             // for more details see: https://github.com/Redocly/openapi-cli/issues/349
             replaceRef(node, resolved, ctx);
           } else if (dereference) {
@@ -303,6 +304,16 @@ function makeBundleVisitor(version: OasMajorVersion, dereference: boolean, rootD
     }
 
     return name;
+  }
+
+  function shouldPlaceSchemaReferenceInline(
+    componentType: string,
+    target: { node: any; location: Location },
+    ctx: UserContext,
+  ) {
+    return refBaseName(target.location.source.absoluteRef) === ctx.key
+      && target.location.pointer.slice(2) === '' // slice(2) removes "#/"
+      && componentType === 'schemas'
   }
 
   return visitor;


### PR DESCRIPTION
## What/Why/How?

This is a fix for a `openapi bundle` command when there are external references.

**Prerequisites:**

`definition.yaml`
```yaml
openapi: 3.0.0
info:
  title: My API
  description: It ain't so wonderful, but at least it's mine.
  version: '1.0'
  contact:
    email: me@theintenet.com
    name: me
tags:
  - name: tag1
servers:
  - url: 'https://dev01.internet.com/api/v0'
    description: Development server.

components:
  schemas:
    vendor:
      $ref: ./vendor.schema.yaml
    myvendor:
      $ref: ./vendor.schema.yaml
```

`vendor.schema.yaml`
```yaml
title: vendor
type: object
description: Vendors
properties:
  key:
    type: string
    description: System-assigned key for the vendor.
    readOnly: true
  id:
    type: string
    description: |
      Unique identifier of the vendor.
      You must specify a unique vendor ID when creating a vendor unless document sequencing is configured, in which case the ID is auto-generated.
  name:
    type: string
    description: Name of the vendor.
  isOneTimeUse:
    type: boolean
    description: One-time use
    default: false

```

After running `openapi bundle definition.yaml`

<details>
   <summary>Original Result</summary>

```yaml
   openapi: 3.0.0
info:
  title: My API
  description: It ain't so wonderful, but at least it's mine.
  version: '1.0'
  contact:
    email: me@theintenet.com
    name: me
tags:
  - name: tag1
servers:
  - url: 'https://dev01.internet.com/api/v0'
    description: Development server.
components:
  schemas:
    vendor:
      $ref: '#/components/schemas/vendor-2'
    myvendor:
       $ref: '#/components/schemas/vendor-2'
    vendor-2:
      title: vendor
      type: object
      description: Vendors
```

</details>

<details>
   <summary>Result after fix</summary>
   ```yaml
openapi: 3.0.0
info:
  title: My API
  description: It ain't so wonderful, but at least it's mine.
  version: '1.0'
  contact:
    email: me@theintenet.com
    name: me
tags:
  - name: tag1
servers:
  - url: https://dev01.internet.com/api/v0
    description: Development server.
components:
  schemas:
    vendor:
      title: vendor
      type: object
      description: Vendors
      properties:
        key:
          type: string
          description: System-assigned key for the vendor.
          readOnly: true
        id:
          type: string
          description: >
            Unique identifier of the vendor.
            You must specify a unique vendor ID when creating a vendor unless
            document sequencing is configured, in which case the ID is
            auto-generated.
        name:
          type: string
          description: Name of the vendor.
        isOneTimeUse:
          type: boolean
          description: One-time use
          default: false
    myvendor:
      $ref: '#/components/schemas/vendor'
```
</details>

## Reference

Fixes [#439](https://github.com/Redocly/openapi-cli/issues/349)

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
