### PR TITLE
chore: 1.0.0-beta.68

### DIFF
--- a/.github/workflows/deploy-s3-sandbox.yaml
+++ b/.github/workflows/deploy-s3-sandbox.yaml
@@ -21,8 +21,8 @@ jobs:
           npm-${{ hashFiles('package-lock.json') }}
           npm-
 
-    - name: Install npm@7.23.0
-      run: npm i -g npm@7.23.0
+    - name: Install npm@7.0.2
+      run: npm i -g npm@7.0.2
     - name: Install dependencies
       run: npm install
     - name: Run tests

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,7 +22,7 @@ jobs:
         restore-keys: |
           npm-${{ hashFiles('package-lock.json') }}
           npm-
-    - run: npm i -g npm@7.23.0
+    - run: npm i -g npm@7.0.2
     - run: npm install
     - run: npm test
   deploy:
@@ -42,8 +42,8 @@ jobs:
           npm-${{ hashFiles('package-lock.json') }}
           npm-
 
-    - name: Install npm@7.23.0
-      run: npm i -g npm@7.23.0
+    - name: Install npm@7.0.2
+      run: npm i -g npm@7.0.2
     - name: Install dependencies
       run: npm install
 
@@ -87,8 +87,8 @@ jobs:
           npm-${{ hashFiles('package-lock.json') }}
           npm-
 
-    - name: Install npm@7.23.0
-      run: npm i -g npm@7.23.0
+    - name: Install npm@7.0.2
+      run: npm i -g npm@7.0.2
 
     - name: Install dependencies
       run: npm install

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
         restore-keys: |
           npm-${{ hashFiles('package-lock.json') }}
           npm-
-    - run: npm i -g npm@7.23.0
+    - run: npm i -g npm@7.0.2
     - run: npm install
     - run: npm test && npm run e2e
       env:

--- a/__tests__/bundle/bundle-lint-format/json-format-snapshot.js
+++ b/__tests__/bundle/bundle-lint-format/json-format-snapshot.js
@@ -7,7 +7,7 @@ exports[`E2E bundle lint format bundle lint: should be formatted by format: json
     "warnings": 0,
     "ignored": 0
   },
-  "version": "1.0.0-beta.67",
+  "version": "1.0.0-beta.68",
   "problems": [
     {
       "ruleId": "spec",
@@ -31,7 +31,7 @@ exports[`E2E bundle lint format bundle lint: should be formatted by format: json
     "warnings": 0,
     "ignored": 0
   },
-  "version": "1.0.0-beta.67",
+  "version": "1.0.0-beta.68",
   "problems": []
 }
 ❌ Validation failed with 1 error.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,15 @@ tocMaxDepth: 2
 
 # OpenAPI CLI changelog
 
+## 1.0.0-beta.68 (2021-11-15)
+
+### Fixes
+
+- Resolved an issue with hot reloading when running preview of reference docs with `openapi preview-docs`
+- Resolved an issue with page refresh when pagination is set to `item` or `section`
+- Resolved an issue with inlining external schema when components' names match
+- Resolved an issue with fetching hosted schema on Windows when bundling OAS definition
+
 ## 1.0.0-beta.67 (2021-11-02)
 
 ### Features

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,10 +8,11 @@ tocMaxDepth: 2
 
 ### Fixes
 
-- Resolved an issue with hot reloading when running preview of reference docs with `openapi preview-docs`
-- Resolved an issue with page refresh when pagination is set to `item` or `section`
-- Resolved an issue with inlining external schema when components' names match
-- Resolved an issue with fetching hosted schema on Windows when bundling OAS definition
+- Resolved an issue with hot reloading when running a preview of reference docs with `openapi preview-docs`.
+- Resolved an issue with page refresh when pagination is set to `item` or `section`.
+- Resolved an issue with inlining external schema when components' names match.
+- Resolved an issue with fetching hosted schema on Windows when bundling OAS definitions.
+- Resolved an issue for `no-server-trailing-slash` when server url is a root.
 
 ## 1.0.0-beta.67 (2021-11-02)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redocly/openapi",
-  "version": "1.0.0-beta.67",
+  "version": "1.0.0-beta.68",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@redocly/openapi",
-      "version": "1.0.0-beta.67",
+      "version": "1.0.0-beta.68",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -827,6 +827,7 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
+        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -2193,6 +2194,7 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -3031,7 +3033,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -4041,6 +4044,7 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {
@@ -4922,6 +4926,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -9055,8 +9060,10 @@
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dev": true,
       "dependencies": {
+        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
+        "neo-async": "^2.5.0",
+        "watchpack-chokidar2": "^2.0.1"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",
@@ -9153,6 +9160,7 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/openapi",
-  "version": "1.0.0-beta.67",
+  "version": "1.0.0-beta.68",
   "description": "",
   "private": true,
   "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,7 +34,7 @@
     "Andriy Leliv <andriy@redoc.ly> (https://redoc.ly/)"
   ],
   "dependencies": {
-    "@redocly/openapi-core": "^1.0.0-beta.67",
+    "@redocly/openapi-core": "^1.0.0-beta.68",
     "@types/node": "^14.11.8",
     "assert-node-version": "^1.0.3",
     "chokidar": "^3.5.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/openapi-cli",
-  "version": "1.0.0-beta.67",
+  "version": "1.0.0-beta.68",
   "description": "",
   "license": "MIT",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/openapi-core",
-  "version": "1.0.0-beta.67",
+  "version": "1.0.0-beta.68",
   "description": "",
   "main": "lib/index.js",
   "engines": {


### PR DESCRIPTION
## What/Why/How?

`v1.0.0-beta.68`

Changelog:
- chore: made the dockerhub workflow a consequtive step after publishing ([commit](https://github.com/Redocly/openapi-cli/commit/bfc8473431d00b3ee9ec5350b3b5440b451ea4a8))
- fix: hot reloading + page refresh for section pagination ([#436](https://github.com/Redocly/openapi-cli/pull/436))
- fix: inline dereferenced schema when original schema name matches resolved schema name ([#439](https://github.com/Redocly/openapi-cli/pull/439))
- fix: resolve fetching of hosted schema on windows ([#441](https://github.com/Redocly/openapi-cli/pull/441))
- fix: should not throw error when server url is root ([#448](https://github.com/Redocly/openapi-cli/pull/448))


## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
