### PR TITLE
lock npm version to 7.23.0 in github actions

### DIFF
--- a/.github/workflows/deploy-s3-sandbox.yaml
+++ b/.github/workflows/deploy-s3-sandbox.yaml
@@ -21,8 +21,8 @@ jobs:
           npm-${{ hashFiles('package-lock.json') }}
           npm-
 
-    - name: Install npm@7
-      run: npm i -g npm@7
+    - name: Install npm@7.23.0
+      run: npm i -g npm@7.23.0
     - name: Install dependencies
       run: npm install
     - name: Run tests

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,7 +22,7 @@ jobs:
         restore-keys: |
           npm-${{ hashFiles('package-lock.json') }}
           npm-
-    - run: npm i -g npm@7
+    - run: npm i -g npm@7.23.0
     - run: npm install
     - run: npm test
   deploy:
@@ -42,8 +42,8 @@ jobs:
           npm-${{ hashFiles('package-lock.json') }}
           npm-
 
-    - name: Install npm@7
-      run: npm i -g npm@7
+    - name: Install npm@7.23.0
+      run: npm i -g npm@7.23.0
     - name: Install dependencies
       run: npm install
 
@@ -87,8 +87,8 @@ jobs:
           npm-${{ hashFiles('package-lock.json') }}
           npm-
 
-    - name: Install npm@7
-      run: npm i -g npm@7
+    - name: Install npm@7.23.0
+      run: npm i -g npm@7.23.0
 
     - name: Install dependencies
       run: npm install

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
         restore-keys: |
           npm-${{ hashFiles('package-lock.json') }}
           npm-
-    - run: npm i -g npm@7
+    - run: npm i -g npm@7.23.0
     - run: npm install
     - run: npm test && npm run e2e
       env:


### PR DESCRIPTION
## What/Why/How?

7.7.6 version of npm fails to install dependencies in github actions. Locking to older version 7.23.0

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
