### PR TITLE
fix: paths-kebab-case does not allow trailing slash

### DIFF
--- a/__tests__/lint/no-path-trailing-slash-off/.redocly.yaml
+++ b/__tests__/lint/no-path-trailing-slash-off/.redocly.yaml
@@ -1,0 +1,8 @@
+apiDefinitions:
+  main: ./openapi.yaml
+
+lint:
+  rules:
+    no-path-trailing-slash: off
+    paths-kebab-case: error
+  extends: []

--- a/__tests__/lint/no-path-trailing-slash-off/openapi.yaml
+++ b/__tests__/lint/no-path-trailing-slash-off/openapi.yaml
@@ -1,0 +1,17 @@
+openapi: 3.1.0
+info:
+  title: Example OpenAPI 3 definition.
+  version: 1.0
+  contact:
+    name: qa
+    url: https://swagger.io/specification/#definitions
+    email: email@redoc.ly
+
+paths:
+  /pet/:
+    get:
+      operationId: example
+      summary: summary example
+      responses:
+        '200':
+          description: example description

--- a/__tests__/lint/no-path-trailing-slash-off/snapshot.js
+++ b/__tests__/lint/no-path-trailing-slash-off/snapshot.js
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`E2E lint no-path-trailing-slash-off 1`] = `
+
+validating /openapi.yaml...
+/openapi.yaml: validated in <test>ms
+
+Woohoo! Your OpenAPI definition is valid. 🎉
+
+
+`;

--- a/packages/core/src/rules/common/__tests__/paths-kebab-case.test.ts
+++ b/packages/core/src/rules/common/__tests__/paths-kebab-case.test.ts
@@ -83,4 +83,27 @@ describe('Oas3 paths-kebab-case', () => {
       ]
     `);
   });
+
+  it('should allow trailing slash in path with "paths-kebab-case" rule', async () => {
+      const document = parseYamlToDocument(
+        outdent`
+            openapi: 3.0.0
+            paths:
+              /some/:
+                get:
+                  summary: List all pets
+          `,
+        'foobar.yaml',
+      );
+
+      const results = await lintDocument({
+        externalRefResolver: new BaseResolver(),
+        document,
+        config: makeConfig({
+          'paths-kebab-case': 'error',
+          'no-path-trailing-slash': 'off',
+        }),
+      });
+      expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`Array []`);
+    });
 });

--- a/packages/core/src/rules/common/paths-kebab-case.ts
+++ b/packages/core/src/rules/common/paths-kebab-case.ts
@@ -4,7 +4,7 @@ import { UserContext } from '../../walk';
 export const PathsKebabCase: Oas3Rule | Oas2Rule = () => {
   return {
     PathItem(_path: object, { report, key }: UserContext) {
-      const segments = (key as string).substr(1).split('/');
+      const segments = (key as string).substr(1).split('/').filter(s => s !== ''); // filter out empty segments
       if (!segments.every((segment) => /^{.+}$/.test(segment) || /^[a-z0-9-.]+$/.test(segment))) {
         report({
           message: `\`${key}\` does not use kebab-case.`,


### PR DESCRIPTION
## What/Why/How?

Fixes https://github.com/Redocly/openapi-cli/issues/465

## Reference

https://github.com/Redocly/openapi-cli/issues/465

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
