### PR TITLE
hotfix: fix REDOCLY_DOMAIN backward compatibility

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,13 @@ tocMaxDepth: 2
 
 # OpenAPI CLI changelog
 
+
+## 1.0.0-beta.71 (2021-11-16)
+
+### Fixes
+
+- REDOCLY_DOMAIN backward compatibility
+
 ## 1.0.0-beta.69 (2021-11-16)
 
 ### Features

--- a/packages/core/src/redocly/__tests__/redocly-client.test.ts
+++ b/packages/core/src/redocly/__tests__/redocly-client.test.ts
@@ -44,6 +44,12 @@ describe('RedoclyClient', () => {
     expect(client.domain).toBe(REDOCLY_DOMAIN_US);
   });
 
+  it('should resolve domain by US region when REDOCLY_DOMAIN consists EU domain', () => {
+    process.env.REDOCLY_DOMAIN = REDOCLY_DOMAIN_EU;
+    const client = new RedoclyClient();
+    expect(client.getRegion()).toBe('eu');
+  });
+
   it('should resolve valid tokens data', async () => {
     let spy = jest.spyOn(RedoclyClient.prototype, 'readCredentialsFile').mockImplementation(() => {
       return { us: "accessToken", eu: "eu-accessToken" }

--- a/packages/core/src/redocly/index.ts
+++ b/packages/core/src/redocly/index.ts
@@ -32,9 +32,9 @@ export class RedoclyClient {
     }
 
     if (process.env.REDOCLY_DOMAIN) {
-      return Object.keys(DOMAINS).find(
+      return (Object.keys(DOMAINS).find(
         (region) => DOMAINS[region as Region] === process.env.REDOCLY_DOMAIN,
-      ) || DEFAULT_REGION;
+      ) || DEFAULT_REGION) as Region;
     }
 
     return region || DEFAULT_REGION;

--- a/packages/core/src/redocly/index.ts
+++ b/packages/core/src/redocly/index.ts
@@ -30,6 +30,13 @@ export class RedoclyClient {
       );
       process.exit(1);
     }
+
+    if (process.env.REDOCLY_DOMAIN) {
+      return Object.keys(DOMAINS).find(
+        (region) => DOMAINS[region as Region] === process.env.REDOCLY_DOMAIN,
+      ) || DEFAULT_REGION;
+    }
+
     return region || DEFAULT_REGION;
   }
 

--- a/packages/core/src/redocly/index.ts
+++ b/packages/core/src/redocly/index.ts
@@ -36,8 +36,11 @@ export class RedoclyClient {
         (region) => DOMAINS[region as Region] === process.env.REDOCLY_DOMAIN,
       ) || DEFAULT_REGION) as Region;
     }
-
     return region || DEFAULT_REGION;
+  }
+
+  getRegion(): Region {
+    return this.region;
   }
 
   hasTokens(): boolean {


### PR DESCRIPTION
## What/Why/How?

Backward compatibility of `REDOCLY_DOMAIN` was broken in beta.70 for EU region. Fixing it back.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
