### PR TITLE
fix: fix another backward compatibility issue with regions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,12 @@ tocMaxDepth: 2
 
 # OpenAPI CLI changelog
 
+## 1.0.0-beta.72 (2021-11-16)
+
+### Fixes
+
+- another backward compatibility issue with regions: save old config key to support old portal versions
+
 ## 1.0.0-beta.71 (2021-11-16)
 
 ### Fixes

--- a/packages/core/src/redocly/index.ts
+++ b/packages/core/src/redocly/index.ts
@@ -120,6 +120,7 @@ export class RedoclyClient {
     const credentials = {
       ...this.readCredentialsFile(credentialsPath),
       [this.region!]: accessToken,
+      token: accessToken, // FIXME: backward compatibility, remove on 1.0.0
     };
     this.accessTokens = credentials;
     this.registryApi.setAccessTokens(credentials);


### PR DESCRIPTION
## What/Why/How?

We need to save old config key to support old portal versions.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
