### PR TITLE
feat: add host arg to preview-docs cli command

### DIFF
--- a/docs/commands/preview-docs.md
+++ b/docs/commands/preview-docs.md
@@ -14,7 +14,7 @@ To preview docs using the premium Redocly API reference docs, you must first aut
 
 ```bash
 openapi preview-docs <entrypoint> [branchName]
-openapi preview-docs <entrypoint> [--config=<path>] [--port=<value>] [branchName]
+openapi preview-docs <entrypoint> [--config=<path>] [--port=<value>] [--host=<host>] [branchName]
 openapi preview-docs <entrypoint> [--force] [--help] [--version] [branchName]
 openapi preview-docs <entrypoint> --version
 ```
@@ -28,6 +28,7 @@ Option                    | Type      | Required     | Default     | Description
 `--force`, `-f`           | `boolean` | no           | -           | Generate preview output even when errors occur
 `--help`                  | `boolean` | no           | -           | Show help
 `--port`, `-p`            | `number`  | no           | 8080        | Specify the port where the documentation preview can be accessed. You can set any port as long as it is not used by applications in your operating system.
+`--host`, `-h`            | `string`  | no           | 127.0.0.1   | Specify the host where the documentation preview can be accessed.
 `--skip-decorator`        | `array`   | no           | -           | Ignore [certain decorators](#skip-preprocessor-or-decorator)
 `--skip-preprocessor`     | `array`   | no           | -           | Ignore [certain preprocessors](#skip-preprocessor-or-decorator)
 `--use-community-edition` | `boolean` | no           | -           | Force using Redoc Community Edition for docs preview
@@ -85,6 +86,22 @@ openapi preview-docs -port 8888 openapi/openapi.yaml
 ```
 
 Both commands will start the preview on port `8888`, so you can access the docs at `http://localhost:8888`
+
+### Custom host for preview
+
+By default, without using the `host` option, the preview starts on host `127.0.0.1`, so you can access the docs at `http://127.0.0.1:8080` or `http://localhost:8080`
+
+To specify a custom host for the preview, pass the desired value using either short or long option format:
+
+```bash short format
+openapi preview-docs -h 0.0.0.0 openapi/openapi.yaml
+```
+
+```bash long format
+openapi preview-docs --host 0.0.0.0 openapi/openapi.yaml
+```
+
+Both commands will start the preview on host `0.0.0.0`, so you can access the docs at `http://0.0.0.0:8080`
 
 
 ### Skip preprocessor or decorator

--- a/packages/cli/src/commands/preview-docs/index.ts
+++ b/packages/cli/src/commands/preview-docs/index.ts
@@ -1,11 +1,19 @@
 import * as colorette from 'colorette';
 import * as chockidar from 'chokidar';
-import { bundle, loadConfig, ResolveError, YamlParseError, RedoclyClient, getTotals } from "@redocly/openapi-core";
+import {
+  bundle,
+  loadConfig,
+  ResolveError,
+  YamlParseError,
+  RedoclyClient,
+  getTotals,
+} from '@redocly/openapi-core';
 import { getFallbackEntryPointsOrExit } from '../../utils';
 import startPreviewServer from './preview-server/preview-server';
 
 export async function previewDocs(argv: {
   port: number;
+  host: string;
   'use-community-edition'?: boolean;
   config?: string;
   entrypoint?: string;
@@ -18,8 +26,11 @@ export async function previewDocs(argv: {
   let redocOptions: any = {};
   let config = await reloadConfig();
 
-  const entrypoints = await getFallbackEntryPointsOrExit(argv.entrypoint ? [argv.entrypoint] : [], config)
-  const entrypoint = entrypoints[0]
+  const entrypoints = await getFallbackEntryPointsOrExit(
+    argv.entrypoint ? [argv.entrypoint] : [],
+    config,
+  );
+  const entrypoint = entrypoints[0];
 
   let cachedBundle: any;
   const deps = new Set<string>();
@@ -31,7 +42,11 @@ export async function previewDocs(argv: {
   async function updateBundle() {
     process.stdout.write('\nBundling...\n\n');
     try {
-      const { bundle: openapiBundle, problems, fileDependencies } = await bundle({
+      const {
+        bundle: openapiBundle,
+        problems,
+        fileDependencies,
+      } = await bundle({
         ref: entrypoint,
         config,
       });
@@ -47,11 +62,11 @@ export async function previewDocs(argv: {
         process.stdout.write(
           fileTotals.errors === 0
             ? `Created a bundle for ${entrypoint} ${
-              fileTotals.warnings > 0 ? 'with warnings' : 'successfully'
-            }\n`
+                fileTotals.warnings > 0 ? 'with warnings' : 'successfully'
+              }\n`
             : colorette.yellow(
-            `Created a bundle for ${entrypoint} with errors. Docs may be broken or not accurate\n`,
-            ),
+                `Created a bundle for ${entrypoint} with errors. Docs may be broken or not accurate\n`,
+              ),
         );
       }
 
@@ -74,7 +89,7 @@ export async function previewDocs(argv: {
     );
   }
 
-  const hotClients = await startPreviewServer(argv.port, {
+  const hotClients = await startPreviewServer(argv.port, argv.host, {
     getBundle,
     getOptions: () => redocOptions,
     useRedocPro: isAuthorized && !redocOptions.useCommunityEdition,

--- a/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
+++ b/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
@@ -53,6 +53,7 @@ function getPageHTML(
 
 export default async function startPreviewServer(
   port: number,
+  host: string,
   {
     getBundle,
     getOptions,
@@ -137,10 +138,10 @@ export default async function startPreviewServer(
 
   let wsPort = await portfinder.getPortPromise({ port: 32201 });
 
-  const server = startHttpServer(port, handler);
+  const server = startHttpServer(port, host, handler);
   server.on('listening', () => {
     process.stdout.write(
-      `\n  🔎  Preview server running at ${colorette.blue(`http://127.0.0.1:${port}\n`)}`,
+      `\n  🔎  Preview server running at ${colorette.blue(`http://${host}:${port}\n`)}`,
     );
   });
 

--- a/packages/cli/src/commands/preview-docs/preview-server/server.ts
+++ b/packages/cli/src/commands/preview-docs/preview-server/server.ts
@@ -58,8 +58,8 @@ export function respondWithGzip(
   }
 }
 
-export function startHttpServer(port: number, handler: http.RequestListener) {
-  return http.createServer(handler).listen(port);
+export function startHttpServer(port: number, host: string, handler: http.RequestListener) {
+  return http.createServer(handler).listen(port, host);
 }
 
 export function startWsServer(port: number) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -251,6 +251,12 @@ yargs
           default: 8080,
           description: 'Preview port.',
         },
+        host: {
+          alias: 'h',
+          type: 'string',
+          default: '127.0.0.1',
+          description: 'Preview host.',
+        },
         'skip-preprocessor': {
           description: 'Ignore certain preprocessors.',
           array: true,


### PR DESCRIPTION
## What/Why/How?

closes https://github.com/Redocly/openapi-cli/issues/474

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests (I didn't tests for this command)

## Security

- [x] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
