### PR TITLE
chore: export mapTypeToComponent function

### DIFF
--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -136,7 +136,7 @@ export async function bundleDocument(opts: {
   };
 }
 
-function mapTypeToComponent(typeName: string, version: OasMajorVersion) {
+export function mapTypeToComponent(typeName: string, version: OasMajorVersion) {
   switch (version) {
     case OasMajorVersion.Version3:
       switch (typeName) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,4 +47,4 @@ export {
 export { getAstNodeByPointer, getLineColLocation } from './format/codeframes';
 export { formatProblems, OutputFormat, getTotals, Totals } from './format/format';
 export { lint, lint as validate, lintDocument, lintFromString, lintConfig } from './lint';
-export { bundle, bundleDocument } from './bundle';
+export { bundle, bundleDocument, mapTypeToComponent } from './bundle';


### PR DESCRIPTION
## What/Why/How?

Export ```mapTypeToComponent``` function in order to have type to component field mapping (needed by vs-code extension)

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
