### PR TITLE
fix: defer process exit to allow STDOUT pipe to flush

### DIFF
--- a/packages/cli/src/__tests__/commands/bundle.test.ts
+++ b/packages/cli/src/__tests__/commands/bundle.test.ts
@@ -8,9 +8,14 @@ jest.mock('../../utils');
 
 describe('bundle', () => {
   let processExitMock: SpyInstance;
+  let exitCb: any;
 
   beforeAll(() => {
     processExitMock = jest.spyOn(process, 'exit').mockImplementation();
+    jest.spyOn(process, 'once').mockImplementation((_e, cb) => {
+      exitCb = cb;
+      return process.on(_e, cb);
+    });
     jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
   });
 
@@ -48,6 +53,7 @@ describe('bundle', () => {
       '1.0.0',
     );
 
+    exitCb?.();
     expect(processExitMock).toHaveBeenCalledWith(0);
   });
 
@@ -81,6 +87,7 @@ describe('bundle', () => {
       '1.0.0',
     );
 
+    exitCb?.();
     expect(processExitMock).toHaveBeenCalledWith(0);
   });
 
@@ -104,6 +111,7 @@ describe('bundle', () => {
     );
 
     expect(lint).toBeCalledTimes(entrypoints.length);
+    exitCb?.();
     expect(processExitMock).toHaveBeenCalledWith(1);
   });
 

--- a/packages/cli/src/commands/bundle.ts
+++ b/packages/cli/src/commands/bundle.ts
@@ -159,5 +159,5 @@ export async function handleBundle(
 
   // defer process exit to allow STDOUT pipe to flush
   // see https://github.com/nodejs/node-v0.x-archive/issues/3737#issuecomment-19156072
-  process.on('exit', () => process.exit(totals.errors === 0 || argv.force ? 0 : 1));
+  process.once('exit', () => process.exit(totals.errors === 0 || argv.force ? 0 : 1));
 }

--- a/packages/cli/src/commands/bundle.ts
+++ b/packages/cli/src/commands/bundle.ts
@@ -156,5 +156,8 @@ export async function handleBundle(
   }
 
   printUnusedWarnings(config.lint);
-  process.exit(totals.errors === 0 || argv.force ? 0 : 1);
+
+  // defer process exit to allow STDOUT pipe to flush
+  // see https://github.com/nodejs/node-v0.x-archive/issues/3737#issuecomment-19156072
+  process.on('exit', () => process.exit(totals.errors === 0 || argv.force ? 0 : 1));
 }

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -95,5 +95,8 @@ export async function handleLint(
   }
 
   printUnusedWarnings(config.lint);
-  process.exit(totals.errors === 0 || argv['generate-ignore-file'] ? 0 : 1);
+
+  // defer process exit to allow STDOUT pipe to flush
+  // see https://github.com/nodejs/node-v0.x-archive/issues/3737#issuecomment-19156072
+  process.on('exit', () => process.exit(totals.errors === 0 || argv['generate-ignore-file'] ? 0 : 1));
 }

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -98,5 +98,5 @@ export async function handleLint(
 
   // defer process exit to allow STDOUT pipe to flush
   // see https://github.com/nodejs/node-v0.x-archive/issues/3737#issuecomment-19156072
-  process.on('exit', () => process.exit(totals.errors === 0 || argv['generate-ignore-file'] ? 0 : 1));
+  process.once('exit', () => process.exit(totals.errors === 0 || argv['generate-ignore-file'] ? 0 : 1));
 }


### PR DESCRIPTION
## What/Why/How?

When cli is spawned by another node process process.exit does not allow stdout pipe to flush the remaining chunk of data so we get an invalid json.

See https://github.com/nodejs/node-v0.x-archive/issues/3737#issuecomment-19156072 for more details.

## Reference

Discovered during local testing.

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
