### PR TITLE
fix: backslashes in $refs to paths on split command from windows

### DIFF
--- a/packages/cli/src/commands/split/__tests__/fixtures/spec.json
+++ b/packages/cli/src/commands/split/__tests__/fixtures/spec.json
@@ -1,0 +1,48 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "TEST",
+    "description": "TEST",
+    "version": "v1",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "Test": {
+        "nullable": true
+      }
+    }
+  },
+  "paths": {
+    "/test": {
+      "get": {
+        "summary": "test",
+        "operationId": "test",
+        "responses": {
+          "202": {
+            "description": "Test",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Test"
+                },
+                "example": {}
+              }
+            }
+          },
+          "400": {
+            "description": "An error response"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/cli/src/commands/split/__tests__/index.test.ts
+++ b/packages/cli/src/commands/split/__tests__/index.test.ts
@@ -1,0 +1,32 @@
+import { iteratePaths } from '../index';
+import * as path from 'path';
+import * as openapiCore from '@redocly/openapi-core';
+
+jest.mock('../../../utils', () => ({
+  ...jest.requireActual('../../../utils'),
+  writeYaml: jest.fn(),
+}));
+
+describe('#split', () => {
+  it('should have correct paths for mac', () => {
+    const pathsDir = 'test/paths';
+    const openapiDir = 'test';
+
+    jest.spyOn(openapiCore, 'slash').mockImplementation(() => 'paths/test.yaml');
+    jest.spyOn(path, 'relative').mockImplementation(() => 'paths/test.yaml');
+    iteratePaths(require("./fixtures/spec.json"), pathsDir, openapiDir);
+    expect(openapiCore.slash).toHaveBeenCalledWith('paths/test.yaml');
+    expect(path.relative).toHaveBeenCalledWith('test', 'test/paths/test.yaml');
+  });
+
+  it('should have correct paths for windows', () => {
+    const pathsDir = 'test\\paths';
+    const openapiDir = 'test';
+
+    jest.spyOn(openapiCore, 'slash').mockImplementation(() => 'paths\\test.yaml');
+    jest.spyOn(path, 'relative').mockImplementation(() => 'paths\\test.yaml');
+    iteratePaths(require("./fixtures/spec.json"), pathsDir, openapiDir);
+    expect(openapiCore.slash).toHaveBeenCalledWith('paths\\test.yaml');
+    expect(path.relative).toHaveBeenCalledWith('test', 'test\\paths/test.yaml');
+  });
+});

--- a/packages/cli/src/commands/split/index.ts
+++ b/packages/cli/src/commands/split/index.ts
@@ -270,7 +270,6 @@ function iteratePaths(
           };
         }
       }
-
       writeYaml(pathData, pathFile);
       paths[oasPath] = {
         $ref: slash(path.relative(openapiDir, pathFile))
@@ -330,4 +329,8 @@ function iterateComponents(
       removeEmptyComponents(openapi, componentType);
     }
   }
+}
+
+export {
+  iteratePaths,
 }

--- a/packages/cli/src/commands/split/index.ts
+++ b/packages/cli/src/commands/split/index.ts
@@ -1,6 +1,6 @@
 import { red, blue, yellow, green } from 'colorette';
 import * as fs from 'fs';
-import { parseYaml } from '@redocly/openapi-core';
+import { parseYaml, slash } from '@redocly/openapi-core';
 import * as path from 'path';
 import { performance } from 'perf_hooks';
 const isEqual = require('lodash.isequal');
@@ -266,14 +266,14 @@ function iteratePaths(
           fs.writeFileSync(sampleFileName, sample.source);
           // @ts-ignore
           sample.source = {
-            $ref: path.relative(pathsDir, sampleFileName)
+            $ref: slash(path.relative(pathsDir, sampleFileName))
           };
         }
       }
 
       writeYaml(pathData, pathFile);
       paths[oasPath] = {
-        $ref: path.relative(openapiDir, pathFile)
+        $ref: slash(path.relative(openapiDir, pathFile))
       };
     }
   }


### PR DESCRIPTION
## What/Why/How?
fix: https://github.com/Redocly/openapi-cli/issues/484

I'll try to add some unit tests for this case since there is not any for this file so far.
## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
