### PR TITLE
feat: add checkstyle as new lint format

### DIFF
--- a/__tests__/bundle/bundle-lint-format/checkstyle-format-snapshot.js
+++ b/__tests__/bundle/bundle-lint-format/checkstyle-format-snapshot.js
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`E2E bundle lint format bundle lint: should be formatted by format: checkstyle 1`] = `
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle version="4.3">
+<file name="openapi.yaml">
+<error line="20" column="11" severity="error" message="Expected type \`MediaType\` (object) but got \`null\`" source="spec" />
+</file>
+</checkstyle>
+No configurations were defined in extends -- using built in recommended configuration by default.
+
+❌ Validation failed with 1 error.
+run \`openapi lint --generate-ignore-file\` to add all problems to the ignore file.
+
+bundling ./openapi.yaml...
+📦 Created a bundle for ./openapi.yaml at /tmp/null.yaml <test>ms.
+
+`;

--- a/__tests__/bundle/bundle-lint-format/checkstyle-format-snapshot.js
+++ b/__tests__/bundle/bundle-lint-format/checkstyle-format-snapshot.js
@@ -7,6 +7,7 @@ exports[`E2E bundle lint format bundle lint: should be formatted by format: chec
 <error line="20" column="11" severity="error" message="Expected type \`MediaType\` (object) but got \`null\`" source="spec" />
 </file>
 </checkstyle>
+
 No configurations were defined in extends -- using built in recommended configuration by default.
 
 ❌ Validation failed with 1 error.

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -161,7 +161,7 @@ describe('E2E', () => {
       ];
     });
 
-    test.each(['codeframe','stylish','json'])('bundle lint: should be formatted by format: %s', (format) => {
+    test.each(['codeframe','stylish','json','checkstyle'])('bundle lint: should be formatted by format: %s', (format) => {
       const params = [...args, `--format=${format}`];
       const result = getBundleResult(params);
       (<any>expect(result)).toMatchSpecificSnapshot(join(folderPath, `${format}-format-snapshot.js`));

--- a/docs/commands/bundle.md
+++ b/docs/commands/bundle.md
@@ -160,11 +160,9 @@ bundling pet.yaml...
 📦 Created a bundle for pet.yaml at bundled/pet.yaml 35ms.
 ```
 
-In this format, `bundle` shows the result of bundling in the [Checkstyle] XML
-report format. Note: this format will only report linting results, so it only
-makes sense to be used in conjunction with the `--lint` option.
-
-[Checkstyle]: https://checkstyle.org/
+In this format, `bundle` uses the [Checkstyle](https://checkstyle.org/) XML report format.
+Due to the limitations of this format, only file name, line, column, severity,
+and rule ID (in the `source` attribute) are included. All other information is omitted.
 
 ### Skip preprocessor, rule, or decorator
 

--- a/docs/commands/bundle.md
+++ b/docs/commands/bundle.md
@@ -32,7 +32,7 @@ Option                 | Type      | Required?    | Default     | Description
 `--ext`                | `string`  | no           | `yaml`      | Specify bundled file extension.<br />**Possible values:** `json`, `yaml`, `yml`
 `--extends`            | `array`   | no           | -           | Can be used in combination with `--lint` to [Extend a specific configuration](./lint.md#extend-configuration) (defaults or config file settings)
 `--force`, `-f`        | `boolean` | no           | -           | Generate bundle output even when errors occur
-`--format`             | `string`  | no           | `codeframe` | Format for the output.<br />**Possible values:** `codeframe`, `stylish`, `json`
+`--format`             | `string`  | no           | `codeframe` | Format for the output.<br />**Possible values:** `codeframe`, `stylish`, `json`, `checkstyle`
 `--help`               | `boolean` | no           | -           | Show help
 `--lint`               | `boolean` | no           | `false`     | Lint definition files.
 `--max-problems`       | `number`  | no           | 100         | Truncate output to display the specified maximum number of problems
@@ -143,6 +143,28 @@ bundling store.yaml...
 ```
 
 In this format, `bundle` shows the result of bundling (including the number of errors and warnings and their descriptions) in JSON-like output.
+
+#### Checkstyle
+
+```bash request
+openapi bundle pet.yaml -o ./bundled --lint --format=checkstyle
+```
+
+```bash output
+bundling pet.yaml...
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle version="4.3">
+<file name="pet.yaml">
+</file>
+</checkstyle>
+📦 Created a bundle for pet.yaml at bundled/pet.yaml 35ms.
+```
+
+In this format, `bundle` shows the result of bundling in the [Checkstyle] XML
+report format. Note: this format will only report linting results, so it only
+makes sense to be used in conjunction with the `--lint` option.
+
+[Checkstyle]: https://checkstyle.org/
 
 ### Skip preprocessor, rule, or decorator
 

--- a/docs/commands/lint.md
+++ b/docs/commands/lint.md
@@ -159,12 +159,10 @@ openapi lint --format=checkstyle
 </checkstyle>
 ```
 
-Writes linting results to standard output in the [Checkstyle] XML report format.
-Due to the limitations of this format, only file name, line, column, severity
+In this format, `lint` uses the [Checkstyle](https://checkstyle.org/) XML report format.
+Due to the limitations of this format, only file name, line, column, severity,
 and rule ID (in the `source` attribute) are included. All other information is
 omitted.
-
-[Checkstyle]: https://checkstyle.org/
 
 ### Max problems
 

--- a/docs/commands/lint.md
+++ b/docs/commands/lint.md
@@ -27,7 +27,7 @@ Option                   | Type      | Required    | Default     | Description
 `entrypoints`            | `array`   | no           | -           | Array of API definition filenames that need to be linted. See [the Entrypoints section](#entrypoints) for more options
 `--config`               | `string`  | no           | -           | Specify path to the [config file](#custom-configuration-file)
 `--extends`              | `array`   | no           | -           | [Extend a specific configuration](#extend-configuration) (defaults or config file settings)
-`--format`               | `string`  | no           | `codeframe` | Format for the output.<br />**Possible values:** `codeframe`, `stylish`
+`--format`               | `string`  | no           | `codeframe` | Format for the output.<br />**Possible values:** `codeframe`, `stylish`, `json`, `checkstyle`
 `--generate-ignore-file` | `boolean` | no           | -           | [Generate ignore file](#generate-ignore-file)
 `--help`                 | `boolean` | no           | -           | Show help
 `--max-problems`         | `number`  | no           | 100         | Truncate output to display the specified [maximum number of problems](#max-problems)
@@ -141,6 +141,30 @@ openapi/core.yaml:
 ```
 
 In this format, `lint` shows the file name, line number, and column where the problem occurred. However, the output is compressed and omits other contexts and suggestions.
+
+#### Checkstyle
+
+```bash request
+openapi lint --format=checkstyle
+```
+
+```bash output
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle version="4.3">
+<file name="openapi/core.yaml">
+<error line="15" column="7" severity="error" message="Property `operationIds` is not expected here." source="spec" />
+<error line="22" column="11" severity="error" message="Property `require` is not expected here." source="spec" />
+<error line="14" column="7" severity="warning" message="Operation object should contain `operationId` field." source="operation-operationId" />
+</file>
+</checkstyle>
+```
+
+Writes linting results to standard output in the [Checkstyle] XML report format.
+Due to the limitations of this format, only file name, line, column, severity
+and rule ID (in the `source` attribute) are included. All other information is
+omitted.
+
+[Checkstyle]: https://checkstyle.org/
 
 ### Max problems
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -104,7 +104,7 @@ yargs
       yargs.positional('entrypoints', { array: true, type: 'string', demandOption: true }).option({
         format: {
           description: 'Use a specific output format.',
-          choices: ['stylish', 'codeframe', 'json'] as ReadonlyArray<OutputFormat>,
+          choices: ['stylish', 'codeframe', 'json', 'checkstyle'] as ReadonlyArray<OutputFormat>,
           default: 'codeframe' as OutputFormat,
         },
         'max-problems': {
@@ -151,7 +151,7 @@ yargs
         output: { type: 'string', alias: 'o' },
         format: {
           description: 'Use a specific output format.',
-          choices: ['stylish', 'codeframe', 'json'] as ReadonlyArray<OutputFormat>,
+          choices: ['stylish', 'codeframe', 'json', 'checkstyle'] as ReadonlyArray<OutputFormat>,
           default: 'codeframe' as OutputFormat,
         },
         'max-problems': {

--- a/packages/core/src/format/format.ts
+++ b/packages/core/src/format/format.ts
@@ -129,28 +129,17 @@ export function formatProblems(
     }
     case 'checkstyle': {
       const groupedByFile = groupByFiles(problems);
-      const writeln = (line: string) => process.stdout.write(`${line}\n`);
 
-      writeln('<?xml version="1.0" encoding="UTF-8"?>');
-      writeln('<checkstyle version="4.3">');
+      process.stdout.write('<?xml version="1.0" encoding="UTF-8"?>\n');
+      process.stdout.write('<checkstyle version="4.3">\n');
 
       for (const [file, { fileProblems }] of Object.entries(groupedByFile)) {
-        writeln(`<file name="${xmlEscape(path.relative(cwd, file))}">`);
-        for (let i = 0; i < fileProblems.length; i++) {
-          const problem = fileProblems[i];
-          const { line, col } = problem.location[0].start;
-          const severity = problem.severity == 'warn' ? 'warning' : 'error';
-          const message = xmlEscape(problem.message);
-          const source = xmlEscape(problem.ruleId);
-          writeln(
-            `<error line="${line}" column="${col}" severity="${severity}" message="${message}" source="${source}" />`,
-          );
-        }
-
-        writeln(`</file>`);
+        process.stdout.write(`<file name="${xmlEscape(path.relative(cwd, file))}">\n`);
+        fileProblems.forEach(formatCheckstyle);
+        process.stdout.write(`</file>\n`);
       }
 
-      writeln(`</checkstyle>`);
+      process.stdout.write(`</checkstyle>\n`);
       break;
     }
   }
@@ -230,6 +219,16 @@ export function formatProblems(
     return `  ${`${start.line}:${start.col}`.padEnd(
       locationPad,
     )}  ${severityName}  ${problem.ruleId.padEnd(ruleIdPad)}  ${problem.message}`;
+  }
+
+  function formatCheckstyle(problem: OnlyLineColProblem) {
+    const { line, col } = problem.location[0].start;
+    const severity = problem.severity == 'warn' ? 'warning' : 'error';
+    const message = xmlEscape(problem.message);
+    const source = xmlEscape(problem.ruleId);
+    process.stdout.write(
+      `<error line="${line}" column="${col}" severity="${severity}" message="${message}" source="${source}" />\n`,
+    );
   }
 }
 


### PR DESCRIPTION
## What/Why/How?

Add another format for linting: Checkstyle. Can be used to pipe linting results into Jenkins, for example. Implementation is adapted from the one [found in ESLint](https://github.com/eslint/eslint/blob/v8.6.0/lib/cli-engine/formatters/checkstyle.js).

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
