### PR TITLE
fix: remove-x-internal decorator doesn't remove references to x-internal components

### DIFF
--- a/packages/core/src/rules/__tests__/hide-internals.test.ts
+++ b/packages/core/src/rules/__tests__/hide-internals.test.ts
@@ -1,5 +1,5 @@
 import { outdent } from 'outdent';
-import { bundleDocument } from '../../bundle'
+import { bundleDocument } from '../../bundle';
 import { BaseResolver } from '../../resolve';
 import { parseYamlToDocument, yamlSerializer } from '../../../__tests__/utils';
 import { makeConfig } from './config';
@@ -19,23 +19,23 @@ describe('oas3 remove-x-internal', () => {
         parameters:
           x:
             name: x
-    `);
+    `,
+  );
 
   it('should use `internalFlagProperty` option to remove internal paths', async () => {
     const { bundle: res } = await bundleDocument({
       document: testDocument,
       externalRefResolver: new BaseResolver(),
-      config: makeConfig({}, { 'remove-x-internal': { 'internalFlagProperty': 'removeit' } })
+      config: makeConfig({}, { 'remove-x-internal': { internalFlagProperty: 'removeit' } }),
     });
-    expect(res.parsed).toMatchInlineSnapshot(
-    `
-    openapi: 3.0.0
-    components:
-      parameters:
-        x:
-          name: x
+    expect(res.parsed).toMatchInlineSnapshot(`
+          openapi: 3.0.0
+          components:
+            parameters:
+              x:
+                name: x
 
-    `);
+        `);
   });
 
   it('should clean types: Server, Operation, Parameter, PathItem, Example', async () => {
@@ -88,14 +88,14 @@ describe('oas3 remove-x-internal', () => {
               name: x
             y:
               name: y
-      `);
-      const { bundle: res } = await bundleDocument({
-        document: testDoc,
-        externalRefResolver: new BaseResolver(),
-        config: makeConfig({}, { 'remove-x-internal': 'on' })
-      });
-      expect(res.parsed).toMatchInlineSnapshot(
-      `
+      `,
+    );
+    const { bundle: res } = await bundleDocument({
+      document: testDoc,
+      externalRefResolver: new BaseResolver(),
+      config: makeConfig({}, { 'remove-x-internal': 'on' }),
+    });
+    expect(res.parsed).toMatchInlineSnapshot(`
       openapi: 3.1.0
       paths:
         /pet:
@@ -115,8 +115,7 @@ describe('oas3 remove-x-internal', () => {
           'y':
             name: 'y'
 
-      `
-      );
+      `);
   });
 
   it('should clean types: Schema, Response, RequestBody, MediaType, Callback', async () => {
@@ -162,14 +161,15 @@ describe('oas3 remove-x-internal', () => {
                     servers:
                       - url: //callback-url.path-level/v1
                         description: Path level server
-      `);
-      const { bundle: res } = await bundleDocument({
-        document: testDoc,
-        externalRefResolver: new BaseResolver(),
-        config: makeConfig({}, { 'remove-x-internal': 'on' })
-      });
-      expect(res.parsed).toMatchInlineSnapshot(
-      `
+      `,
+    );
+    const { bundle: res } = await bundleDocument({
+      document: testDoc,
+      externalRefResolver: new BaseResolver(),
+      config: makeConfig({}, { 'remove-x-internal': 'on' }),
+    });
+
+    expect(res.parsed).toMatchInlineSnapshot(`
       openapi: 3.1.0
       paths:
         /pet:
@@ -186,127 +186,88 @@ describe('oas3 remove-x-internal', () => {
       `);
   });
 
-  it('should clean refs', async () => {
+  it('should remove refs', async () => {
     const testDoc = parseYamlToDocument(
       outdent`
         openapi: 3.0.1
         info:
           version: 1.0.0
-          title: Products API
-          description: Manages products.
+          title: Test API
         paths:
-          /products:
+          /test1:
             get:
-              summary: List products
-              description: Retrieves a paginated list of products.
-              operationId: list-products
               parameters:
-                - $ref: '#/components/parameters/Vendor'
+                - $ref: '#/components/parameters/Internal'
                 - in: query
-                  name: filter[owner_id]
-                  description: Allows filtering by owner_id.
+                  name: inline
                   schema:
                     type: string
                 - in: query
-                  name: filter[external_id]
-                  description: Allows filtering by external_id.
+                  name: inline-internal
                   schema:
                     type: string
                   x-internal: true
-              responses:
-                '200':
-                  description: Successful response.
-                  content:
-                    application/json:
-                      schema:
-                        type: object
-          /products/{product_id}:
+          /test2:
             get:
-              summary: Get product
-              description: Retrieves the specified product.
-              operationId: get-product
               parameters:
-                - $ref: '#/components/parameters/ProductID'
-                - $ref: '#/components/parameters/Vendor'
+                - $ref: '#/components/parameters/Public'
+                - $ref: '#/components/parameters/Internal'
               requestBody:
-                $ref: '#/components/requestBodies/UserArray'
+                $ref: '#/components/requestBodies/Public'
         components:
           requestBodies:
-            UserArray:
+            Public:
               content:
                 application/json:
                   schema:
-                    type: array
-              description: List of user object
+                    type: string
               required: true
               x-internal: true
           parameters:
-            ProductID:
+            Public:
               in: path
               name: product_id
-              description: The ID of the product.
-              required: true
               schema:
                 type: string
-                format: uuid
-            Vendor:
+            Internal:
               in: header
               name: X-Vendor
-              description: The vendor.
               schema:
                 type: string
               x-internal: true
-      `);
-      const { bundle: res } = await bundleDocument({
-        document: testDoc,
-        externalRefResolver: new BaseResolver(),
-        config: makeConfig({}, { 'remove-x-internal': 'on' })
-      });
-      expect(res.parsed).toMatchInlineSnapshot(
-      `
+      `,
+    );
+    const { bundle: res } = await bundleDocument({
+      document: testDoc,
+      externalRefResolver: new BaseResolver(),
+      config: makeConfig({}, { 'remove-x-internal': 'on' }),
+    });
+    expect(res.parsed).toMatchInlineSnapshot(`
       openapi: 3.0.1
       info:
         version: 1.0.0
-        title: Products API
-        description: Manages products.
+        title: Test API
       paths:
-        /products:
+        /test1:
           get:
-            summary: List products
-            description: Retrieves a paginated list of products.
-            operationId: list-products
             parameters:
               - in: query
-                name: filter[owner_id]
-                description: Allows filtering by owner_id.
+                name: inline
                 schema:
                   type: string
-            responses:
-              '200':
-                description: Successful response.
-                content:
-                  application/json:
-                    schema:
-                      type: object
-        /products/{product_id}:
+        /test2:
           get:
-            summary: Get product
-            description: Retrieves the specified product.
-            operationId: get-product
             parameters:
-              - $ref: '#/components/parameters/ProductID'
+              - $ref: '#/components/parameters/Public'
       components:
         parameters:
-          ProductID:
+          Public:
             in: path
             name: product_id
-            description: The ID of the product.
-            required: true
             schema:
               type: string
-              format: uuid
 
-      `);
+    `);
   });
 });
 
@@ -337,21 +298,20 @@ describe('oas2 remove-x-internal', () => {
                 '200':
                   x-internal: true
                   description: List of recent media entries.
-      `);
+      `,
+    );
     const { bundle: res } = await bundleDocument({
       document: testDoc,
       externalRefResolver: new BaseResolver(),
-      config: makeConfig({}, { 'remove-x-internal': 'on' })
+      config: makeConfig({}, { 'remove-x-internal': 'on' }),
     });
-    expect(res.parsed).toMatchInlineSnapshot(
-    `
-    swagger: '2.0'
-    host: api.instagram.com
-    paths:
-      /geographies/{geo-id}/media/recent:
-        get: {}
+    expect(res.parsed).toMatchInlineSnapshot(`
+          swagger: '2.0'
+          host: api.instagram.com
+          paths:
+            /geographies/{geo-id}/media/recent:
+              get: {}
 
-    `
-    );
+        `);
   });
 });

--- a/packages/core/src/rules/__tests__/hide-internals.test.ts
+++ b/packages/core/src/rules/__tests__/hide-internals.test.ts
@@ -294,17 +294,17 @@ describe('oas3 remove-x-internal', () => {
             description: Retrieves the specified product.
             operationId: get-product
             parameters:
-              - &ref_0
-                in: path
-                name: product_id
-                description: The ID of the product.
-                required: true
-                schema:
-                  type: string
-                  format: uuid
+              - $ref: '#/components/parameters/ProductID'
       components:
         parameters:
-          ProductID: *ref_0
+          ProductID:
+            in: path
+            name: product_id
+            description: The ID of the product.
+            required: true
+            schema:
+              type: string
+              format: uuid
 
       `);
   });

--- a/packages/core/src/rules/common/remove-x-internal.ts
+++ b/packages/core/src/rules/common/remove-x-internal.ts
@@ -12,6 +12,9 @@ export const RemoveXInternal: Oas3Decorator | Oas2Decorator = ({ internalFlagPro
     let didDelete = false;
     if (Array.isArray(node)) {
       for (let i = 0; i < node.length; i++) {
+        if (node[i]["$ref"]) {
+          node[i] = ctx.resolve({ $ref: node[i]["$ref"] }).node;
+        }
         if (node[i] && node[i][hiddenTag]) {
           node.splice(i, 1);
           didDelete = true;
@@ -20,8 +23,12 @@ export const RemoveXInternal: Oas3Decorator | Oas2Decorator = ({ internalFlagPro
       }
     } else if (isPlainObject(node)) {
       for (const key of Object.keys(node)) {
-        if ((node as any)[key][hiddenTag]) {
-          delete (node as any)[key];
+        node = node as any;
+        if (node[key]["$ref"]) {
+          node[key] = ctx.resolve({ $ref: node[key]["$ref"] }).node;
+        }
+        if (node[key][hiddenTag]) {
+          delete node[key];
           didDelete = true;
         }
       }

--- a/packages/core/src/rules/common/remove-x-internal.ts
+++ b/packages/core/src/rules/common/remove-x-internal.ts
@@ -17,6 +17,8 @@ export const RemoveXInternal: Oas3Decorator | Oas2Decorator = ({ internalFlagPro
           const resolved = ctx.resolve(node[i]);
           if (resolved.node?.[hiddenTag]) {
             node.splice(i, 1);
+            didDelete = true;
+            i--;
           }
         }
         if (node[i]?.[hiddenTag]) {
@@ -32,6 +34,7 @@ export const RemoveXInternal: Oas3Decorator | Oas2Decorator = ({ internalFlagPro
           const resolved = ctx.resolve(node[key]);
           if (resolved.node?.[hiddenTag]) {
             delete node[key];
+            didDelete = true;
           }
         }
         if (node[key]?.[hiddenTag]) {


### PR DESCRIPTION
## What/Why/How?
Closes #501


## Check yourself
- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security
- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
