### PR TITLE
fix: cleanup version in e2e tests

### DIFF
--- a/__tests__/bundle/bundle-lint-format/json-format-snapshot.js
+++ b/__tests__/bundle/bundle-lint-format/json-format-snapshot.js
@@ -7,7 +7,6 @@ exports[`E2E bundle lint format bundle lint: should be formatted by format: json
     "warnings": 0,
     "ignored": 0
   },
-  "version": "1.0.0-beta.78",
   "problems": [
     {
       "ruleId": "spec",
@@ -31,7 +30,6 @@ exports[`E2E bundle lint format bundle lint: should be formatted by format: json
     "warnings": 0,
     "ignored": 0
   },
-  "version": "1.0.0-beta.78",
   "problems": []
 }
 No configurations were defined in extends -- using built in recommended configuration by default.

--- a/__tests__/bundle/bundle-lint-format/json-format-snapshot.js
+++ b/__tests__/bundle/bundle-lint-format/json-format-snapshot.js
@@ -7,6 +7,7 @@ exports[`E2E bundle lint format bundle lint: should be formatted by format: json
     "warnings": 0,
     "ignored": 0
   },
+  "version": "<version>",
   "problems": [
     {
       "ruleId": "spec",
@@ -30,6 +31,7 @@ exports[`E2E bundle lint format bundle lint: should be formatted by format: json
     "warnings": 0,
     "ignored": 0
   },
+  "version": "<version>",
   "problems": []
 }
 No configurations were defined in extends -- using built in recommended configuration by default.

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -17,7 +17,7 @@ addSerializer({
 });
 
 function cleanUpVersion(str: string): string {
-  return str.replace(/"version":\s(\".*\"),\s*/g, '');
+  return str.replace(/"version":\s(\".*\")*/g, '"version": "<version>"');
 }
 
 function getEntrypoints(folderPath: string) {

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -13,8 +13,12 @@ expect.extend({
 
 addSerializer({
   test: (val: any) => typeof val === 'string',
-  print: (v: any) => v as string,
+  print: (v: any) => cleanUpVersion(v),
 });
+
+function cleanUpVersion(str: string): string {
+  return str.replace(/"version":\s(\".*\"),\s*/g, '');
+}
 
 function getEntrypoints(folderPath: string) {
   const redoclyYamlFile = readFileSync(join(folderPath, ".redocly.yaml"), "utf8");


### PR DESCRIPTION
## What/Why/How?
- remove version in bundle-lint-format test - json format
- add `cleanUpVersion` function to print in Serializer - all snapshots printed without package version

## Check yourself
- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security
- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
