### PR TITLE
docs: add assertions docs

### DIFF
--- a/docs/resources/built-in-rules.md
+++ b/docs/resources/built-in-rules.md
@@ -330,6 +330,10 @@ Verifies that each tag has a description.
 
 Verifies that tags (names) are declared in alphabetical order.
 
+### assertions
+
+Configure assertions to enforce your API design standards without coding custom rules.
+Learn how to [configure assertions](./rules/assertions.md).
 
 ## Recommended config
 

--- a/docs/resources/rules/assertions.md
+++ b/docs/resources/rules/assertions.md
@@ -1,0 +1,312 @@
+# `assertions`
+
+Configure assertions to enforce your API design standards without coding custom rules.
+
+Define the `assertions` key in the lint rules of the configuration file.
+
+```yaml
+lint:
+  rules:
+    assertions: ...
+```
+
+Property | Type | Description
+-- | -- | --
+assertions | [[Assertion object]](#assertion-object) | A list of assertions to enforce your custom API design standards. Add or edit your assertions in the configuration file. The `assertions` rule is composed of a list of `assertion` objects. This rule may result in more than one problem message as you may define more than one assertion. More than one assertion may be defined, and an assertion may have more than one assert.
+
+## Assertion object
+
+Property | Type | Description
+-- | -- | --
+on | `string` \| [`string`] | **REQUIRED.** The node type, or list of node types, to the lint targets. Nodes are traversed with a dot `.` between nodes, and can start from any [OpenAPI node type](#openapi-node-types). A special value `$keys` can be used to target the keys of any map (for example, `ResponseMap.$keys`).
+description | `string` | Problem message displayed if the assertion is false.
+severity | `string` | The severity level of the problem if the assertion is false. It must be one of these values: `error`, `warn`, `off`. Default value is `error`.
+enum | [`string`] | Asserts value is within a predefined list of values. See [enum example](#enum-example).
+pattern | `string` | Asserts value matches a regex pattern. See [regex pattern example](#regex-pattern-example).
+casing | `string` | Asserts a casing style from this possible list: `camelCase`, `kebab-case`, `snake_case`, `PascalCase`, `MACRO_CASE`, `COBOL-CASE`, `flatcase`. See [casing example](#casing-example).
+mutuallyExclusive | [`string`] | Asserts list of properties (key names only) are mutually exclusive. Use `$keys` in the `on` when this is enabled (for example, `Operation.$keys`). See [mutuallyExclusive example](#mutuallyexclusie-example).
+mutuallyRequired | [`string`] | Asserts list of properties (key names only) are mutually required. Use `$keys` in the `on` when this is enabled (for example, `Operation.$keys`). See [mutuallyRequired example](#mutuallyrequired-example).
+defined | `boolean` | Asserts a property is defined. See [defined example](#defined-example).
+undefined | `boolean` | Asserts a property is undefined. See [undefined example](#undefined-example).
+nonEmpty | `boolean` | Asserts a property is not empty. See [nonEmpty example](#nonempty-example).
+length | `integer` | Asserts a length of a string or list (array). See [length example](#length-example).
+minLength | `integer` | Asserts a minimum length (inclusive) of a string or list (array). See [minLength example](#minlength-example).
+maxLength | `integer` | Asserts a maximum length (exclusive) of a string or list (array). See [maxLength example](#maxlength-example).
+
+
+## Examples
+
+The following example shows two assertions each multiple asserts (`defined`, `minLength`, `maxLength`, `pattern`).
+
+The `Operation`, `Tag`, and `Info` properties must:
+- be defined
+- have at least 30 characters
+- end with a "_full stop_".
+
+In addition, the `Operation` summary property must:
+- be defined
+- be between 20 and 60 characters
+- not end with a "_full stop_".
+
+The following shows how to write that configuration:
+
+```yaml
+lint:
+  rules:
+    assertions:
+      - on:
+          - Tag.description
+          - Operation.description
+          - Info.description
+        message: Description must be at least 30 characters and end with a full stop.
+        severity: error
+        defined: true
+        minLength: 30
+        pattern: /(full stop)$/
+      - on:
+          - Operation.summary
+        message: Operation summary must be at least 20 characters and not end with a full stop.
+        severity: error
+        defined: true
+        minLength: 20
+        maxLength: 60
+        pattern: /^(full stop)$/
+      
+```
+<!-- TODO: is the regex not /\\.$/? -->
+
+### `enum` example
+
+Assert that keys or values are in a list of values.
+Append `$keys` to the `on` node value to run on the node's keys.
+
+```yaml keys
+lint:
+  rules:
+    assertions:
+      - on: MediaTypeMap.$keys
+        message: Only application/json can be used
+        severity: error
+        enum:
+          - application/json
+```
+
+```yaml values
+lint:
+  rules:
+    assertions:
+      - on: Operation.summary
+        message: Summary must be one of the predefined values
+        severity: error
+        enum:
+          - one
+          - two
+```
+
+### `pattern` example
+
+This example shows a regex pattern to assert that the operation summary contains "test".
+
+```yaml
+lint:
+  rules:
+    assertions:
+      - on: Operation.summary
+        message: Summary should match a regex
+        severity: error
+        pattern: /test/
+```
+
+### `casing` example
+
+This example enforces `PascalCase` casing style for named Examples keys.
+
+<!-- TODO: Does casing work on keys? I would like to do it on media type examples PascalCase. Please add an example.  -->
+
+```yaml
+lint:
+  rules:
+    assertions:
+      - on: NamedExamples.$keys
+        message: NamedExamples key must be in PascalCase
+        severity: error
+        casing: PascalCase
+```
+
+Casing supports these styles: 
+- camelCase
+- COBOL-CASE
+- flatcase
+- kebab-case
+- snake_case
+- PascalCase
+- MACRO_CASE
+
+
+### `mutuallyExclusive` example
+
+This example asserts the operation `description` and `externalDocs` must be mutually exclusive.
+This assert runs only on node's keys.
+Append `$keys` to the `on` node value to run on the node's keys.
+
+```yaml
+lint:
+  rules:
+    assertions:
+      - on: Operation.$keys
+        message: "Operation must not define both properties together: description and externalDocs"
+        severity: error
+        mutuallyExclusive:
+          - description
+          - externalDocs
+```
+
+### `mutuallyRequired` example
+
+This example asserts that a response body schema must have both `amount` and `currency` properties (and not either one by itself).
+This assertion runs only on node's keys.
+Append `$keys` to the `on` node value to run on the node's keys.
+
+```yaml Schema example
+lint:
+  rules:
+    assertions:
+      # - on: Operation.Response.$keys check this
+        message: The created_at and updated_at properties are mutually required
+        severity: error
+        mutuallyRequired:
+          - created_at
+          - updated_at
+```
+
+This example asserts that PUT requests have both 200 and 201 responses defined.
+
+```yaml Response example
+lint:
+  rules:
+    assertions:
+      - on: PathItem.put.responses.$keys
+        message: Must define 200 and 201 responses for PUT requests.
+        severity: error
+        mutuallyRequired:
+          - '200'
+          - '201'
+```
+
+### `defined` example
+
+This example asserts that `x-codeSamples` is defined.
+
+```yaml
+lint:
+  rules:
+    assertions:
+      - on: Operation.x-codeSamples
+        message: x-codeSamples must be defined
+        severity: error
+        defined: true
+```
+
+### `undefined` example
+
+This example asserts that `x-code-samples` is undefined.
+
+```yaml
+lint:
+  rules:
+    assertions:
+      - on: Operation.x-code-samples
+        message: use x-codeSamples instead of x-code-samples
+        severity: error
+        undefined: true
+```
+
+### `nonEmpty` example
+
+This example asserts that the operation summary is not empty.
+
+```yaml
+lint:
+  rules:
+    assertions:
+      - on: Operation.summary
+        message: Operation summary should not be empty
+        severity: error
+        nonEmpty: true
+```
+
+### `length` example
+
+The example asserts the exact length of the summary string is 20 characters.
+
+```yaml
+lint:
+  rules:
+    assertions:
+      - on: Operation.summary
+        message: Operation summary must have 20 characters
+        severity: error
+        length: 20
+```
+
+The example asserts the list of the status enums is 20 characters exactly.
+
+```yaml
+lint:
+  rules:
+    assertions:
+      - on: Schema.status
+        message: The status property enum must have 20 items
+        severity: error
+        length: 20
+```
+<!-- Help check this example is correct -->
+
+### `minLength` example
+
+This example asserts that the minimum length of each operation summary is 20 characters.
+
+```yaml
+lint:
+  rules:
+    assertions:
+      - on: Operation.summary
+        message: Operation summary must have minimum of 20 chars length
+        severity: error
+        minLength: 20
+```
+
+### `maxLength` example
+
+This example asserts that the maximum length of each operation summary is 20 characters.
+
+```yaml
+lint:
+  rules:
+    assertions:
+      - on: Operation.summary
+        message: Operation summary must have maximum of 20 characters
+        severity: error
+        maxLength: 20
+```
+
+<!-- 
+TODO: discuss
+
+### `sortOrder` example
+
+To enforce sort order in array of strings or array of objects (collection). 
+If the `property` fields is present, it means that we check the sort order direction on collection. 
+Also, in case of array of strings the direction could be also set like `sortOrder: asc`.
+
+```yaml
+lint:
+  rules:
+    assertions:
+      - on: Operation.tags
+        message: Tags should be ordered in ASC direction
+        severity: error
+        sortOrder:
+          direction: asc
+          property: name
+``` -->

--- a/docs/resources/rules/assertions.md
+++ b/docs/resources/rules/assertions.md
@@ -23,9 +23,9 @@ message | `string` | Problem message displayed if the assertion is false.
 suggest | [`string`] | List of suggestions to display if the problem occurs.
 severity | `string` | The severity level of the problem if the assertion is false. It must be one of these values: `error`, `warn`, `off`. Default value is `error`.
 enum | [`string`] | Asserts value is within a predefined list of values. See [enum example](#enum-example).
-pattern | `string` | Asserts value matches a regex pattern. See [regex pattern example](#regex-pattern-example).
+pattern | `string` | Asserts value matches a regex pattern. See [regex pattern example](#pattern-example).
 casing | `string` | Asserts a casing style from this possible list: `camelCase`, `kebab-case`, `snake_case`, `PascalCase`, `MACRO_CASE`, `COBOL-CASE`, `flatcase`. See [casing example](#casing-example).
-mutuallyExclusive | [`string`] | Asserts list of properties (key names only) are mutually exclusive. Use `$keys` in the `on` when this is enabled (for example, `Operation.$keys`). See [mutuallyExclusive example](#mutuallyexclusie-example).
+mutuallyExclusive | [`string`] | Asserts list of properties (key names only) are mutually exclusive. Use `$keys` in the `on` when this is enabled (for example, `Operation.$keys`). See [mutuallyExclusive example](#mutuallyexclusive-example).
 mutuallyRequired | [`string`] | Asserts list of properties (key names only) are mutually required. Use `$keys` in the `on` when this is enabled (for example, `Operation.$keys`). See [mutuallyRequired example](#mutuallyrequired-example).
 defined | `boolean` | Asserts a property is defined. See [defined example](#defined-example).
 undefined | `boolean` | Asserts a property is undefined. See [undefined example](#undefined-example).
@@ -77,7 +77,7 @@ lint:
         defined: true
         minLength: 20
         maxLength: 60
-        pattern: /^\.$/
+        pattern: /[^\.]$/
       
 ```
 

--- a/docs/resources/rules/assertions.md
+++ b/docs/resources/rules/assertions.md
@@ -2,7 +2,7 @@
 
 Configure assertions to enforce your API design standards without coding custom rules.
 
-Define the `assertions` key in the lint rules of the configuration file.
+Define `assertions` in the rules map of the lint section of the configuration file.
 
 ```yaml
 lint:
@@ -19,7 +19,8 @@ assertions | [[Assertion object]](#assertion-object) | A list of assertions to e
 Property | Type | Description
 -- | -- | --
 on | `string` \| [`string`] | **REQUIRED.** The node type, or list of node types, to the lint targets. Nodes are traversed with a dot `.` between nodes, and can start from any [OpenAPI node type](#openapi-node-types). A special value `$keys` can be used to target the keys of any map (for example, `ResponseMap.$keys`).
-description | `string` | Problem message displayed if the assertion is false.
+message | `string` | Problem message displayed if the assertion is false.
+suggest | [`string`] | List of suggestions to display if the problem occurs.
 severity | `string` | The severity level of the problem if the assertion is false. It must be one of these values: `error`, `warn`, `off`. Default value is `error`.
 enum | [`string`] | Asserts value is within a predefined list of values. See [enum example](#enum-example).
 pattern | `string` | Asserts value matches a regex pattern. See [regex pattern example](#regex-pattern-example).
@@ -29,10 +30,16 @@ mutuallyRequired | [`string`] | Asserts list of properties (key names only) are 
 defined | `boolean` | Asserts a property is defined. See [defined example](#defined-example).
 undefined | `boolean` | Asserts a property is undefined. See [undefined example](#undefined-example).
 nonEmpty | `boolean` | Asserts a property is not empty. See [nonEmpty example](#nonempty-example).
-length | `integer` | Asserts a length of a string or list (array). See [length example](#length-example).
 minLength | `integer` | Asserts a minimum length (inclusive) of a string or list (array). See [minLength example](#minlength-example).
 maxLength | `integer` | Asserts a maximum length (exclusive) of a string or list (array). See [maxLength example](#maxlength-example).
+sortOrder | `string` \| [Sort Order object](#sort-order-object) | Asserts a sort order to a list (array) of strings or a list of objects by one of the object's property values. See [sortOrder example](#sortorder-example).
 
+## Sort Order object
+
+Property | Type | Description
+-- | -- | --
+direction | `string` | **REQUIRED.** Asserts values are sorted in ascending or descending order using one of these possible values: `asc` or `desc`.
+property | `string` | **REQUIRED.** The name of the property in the collection of objects that will hold values to assess the sort order.
 
 ## Examples
 
@@ -41,12 +48,12 @@ The following example shows two assertions each multiple asserts (`defined`, `mi
 The `Operation`, `Tag`, and `Info` properties must:
 - be defined
 - have at least 30 characters
-- end with a "_full stop_".
+- end with a _full stop_.
 
 In addition, the `Operation` summary property must:
 - be defined
 - be between 20 and 60 characters
-- not end with a "_full stop_".
+- not end with a _full stop_.
 
 The following shows how to write that configuration:
 
@@ -62,7 +69,7 @@ lint:
         severity: error
         defined: true
         minLength: 30
-        pattern: /(full stop)$/
+        pattern: /\.$/
       - on:
           - Operation.summary
         message: Operation summary must be at least 20 characters and not end with a full stop.
@@ -70,14 +77,13 @@ lint:
         defined: true
         minLength: 20
         maxLength: 60
-        pattern: /^(full stop)$/
+        pattern: /^\.$/
       
 ```
-<!-- TODO: is the regex not /\\.$/? -->
 
 ### `enum` example
 
-Assert that keys or values are in a list of values.
+The following example asserts that only `application/json` can be used as a key of the media type map.
 Append `$keys` to the `on` node value to run on the node's keys.
 
 ```yaml keys
@@ -91,21 +97,26 @@ lint:
           - application/json
 ```
 
+The following example asserts that the operation summary must match one of the listed enums.
+
 ```yaml values
 lint:
   rules:
     assertions:
       - on: Operation.summary
         message: Summary must be one of the predefined values
+        suggest:
+          - change to 'My resource'
+          - change to 'My collection'
         severity: error
         enum:
-          - one
-          - two
+          - My resource
+          - My collection
 ```
 
 ### `pattern` example
 
-This example shows a regex pattern to assert that the operation summary contains "test".
+The following example asserts that the operation summary contains "test".
 
 ```yaml
 lint:
@@ -119,9 +130,7 @@ lint:
 
 ### `casing` example
 
-This example enforces `PascalCase` casing style for named Examples keys.
-
-<!-- TODO: Does casing work on keys? I would like to do it on media type examples PascalCase. Please add an example.  -->
+The following example asserts the casing style is `PascalCase` for named Examples map keys.
 
 ```yaml
 lint:
@@ -145,7 +154,7 @@ Casing supports these styles:
 
 ### `mutuallyExclusive` example
 
-This example asserts the operation `description` and `externalDocs` must be mutually exclusive.
+The following example asserts the operation `description` and `externalDocs` must be mutually exclusive.
 This assert runs only on node's keys.
 Append `$keys` to the `on` node value to run on the node's keys.
 
@@ -163,7 +172,7 @@ lint:
 
 ### `mutuallyRequired` example
 
-This example asserts that a response body schema must have both `amount` and `currency` properties (and not either one by itself).
+The following example asserts that a response body schema must have both `amount` and `currency` properties (and not either one by itself).
 This assertion runs only on node's keys.
 Append `$keys` to the `on` node value to run on the node's keys.
 
@@ -179,7 +188,7 @@ lint:
           - updated_at
 ```
 
-This example asserts that PUT requests have both 200 and 201 responses defined.
+The following example asserts that `PUT` requests have both `200` and `201` responses defined.
 
 ```yaml Response example
 lint:
@@ -195,7 +204,7 @@ lint:
 
 ### `defined` example
 
-This example asserts that `x-codeSamples` is defined.
+The following example asserts that `x-codeSamples` is defined.
 
 ```yaml
 lint:
@@ -209,21 +218,23 @@ lint:
 
 ### `undefined` example
 
-This example asserts that `x-code-samples` is undefined.
+The following example asserts that `x-code-samples` is undefined.
 
 ```yaml
 lint:
   rules:
     assertions:
       - on: Operation.x-code-samples
-        message: use x-codeSamples instead of x-code-samples
+        message: x-code-samples is deprecated
+        suggest: 
+          - x-codeSamples instead of x-code-samples
         severity: error
         undefined: true
 ```
 
 ### `nonEmpty` example
 
-This example asserts that the operation summary is not empty.
+The following example asserts that the operation summary is not empty.
 
 ```yaml
 lint:
@@ -235,36 +246,9 @@ lint:
         nonEmpty: true
 ```
 
-### `length` example
-
-The example asserts the exact length of the summary string is 20 characters.
-
-```yaml
-lint:
-  rules:
-    assertions:
-      - on: Operation.summary
-        message: Operation summary must have 20 characters
-        severity: error
-        length: 20
-```
-
-The example asserts the list of the status enums is 20 characters exactly.
-
-```yaml
-lint:
-  rules:
-    assertions:
-      - on: Schema.status
-        message: The status property enum must have 20 items
-        severity: error
-        length: 20
-```
-<!-- Help check this example is correct -->
-
 ### `minLength` example
 
-This example asserts that the minimum length of each operation summary is 20 characters.
+The following example asserts that the minimum length of each operation summary is 20 characters.
 
 ```yaml
 lint:
@@ -278,7 +262,7 @@ lint:
 
 ### `maxLength` example
 
-This example asserts that the maximum length of each operation summary is 20 characters.
+The following example asserts that the maximum length of each operation summary is 20 characters.
 
 ```yaml
 lint:
@@ -290,23 +274,120 @@ lint:
         maxLength: 20
 ```
 
-<!-- 
-TODO: discuss
-
 ### `sortOrder` example
 
-To enforce sort order in array of strings or array of objects (collection). 
-If the `property` fields is present, it means that we check the sort order direction on collection. 
-Also, in case of array of strings the direction could be also set like `sortOrder: asc`.
+Sort order can be applied on lists (arrays) of strings or lists of objects (collections).
+
+The following example asserts that the status schema's enum list is in alphabetical order.
+
+```yaml
+lint:
+  rules:
+    assertions:
+      - on: Schema.status.enum
+        message: The status enums should be in alphabetical order
+        suggest:
+          - alphabetize the list of status enums
+        severity: error
+        sortOrder: asc
+```
+
+The following example asserts the tag names (tags are a collection) are sorted in alphabetical order.
+
+The `property` field is **REQUIRED** to sort collections based on that property's value. 
 
 ```yaml
 lint:
   rules:
     assertions:
       - on: Operation.tags
-        message: Tags should be ordered in ASC direction
+        message: Tags should be ordered by name in alphabetical order
         severity: error
         sortOrder:
           direction: asc
           property: name
-``` -->
+```
+
+## OpenAPI node types
+
+Redocly defines a type tree based on the document type.
+OpenAPI 2.0 has one type tree.
+OpenAPI 3.0 and OpenAPI 3.1 share a type tree.
+
+Node types are traversed using dot notation.
+
+The following example shows ways to traverse to the equivalent destination.
+One starts from the definition root into the info description.
+The other starts from the info section.
+
+```yaml Traversal from DefinitionRoot object type
+lint:
+  rules:
+    assertions:
+      - on:
+        - DefinitionRoot.info.description
+```
+
+```yaml Traversal from Info object type
+lint:
+  rules:
+    assertions:
+      - on:
+        - Info.description
+```
+
+### List of OpenAPI types
+
+Implementation of types for each specific OAS version:
+  - OAS 3.1: https://github.com/Redocly/openapi-cli/blob/master/packages/core/src/types/oas3_1.ts#L209
+  - OAS 3.0: https://github.com/Redocly/openapi-cli/blob/master/packages/core/src/types/oas3.ts#L530
+  - OAS 2.0: https://github.com/Redocly/openapi-cli/blob/master/packages/core/src/types/oas2.ts#L367
+
+List of types for OpenAPI 3.0 and 3.1:
+
+- DefinitionRoot
+- Tag
+- ExternalDocs
+- Server
+- ServerVariable
+- SecurityRequirement
+- Info
+- Contact
+- License
+- PathMap
+- PathItem
+- Parameter
+- Operation
+- Callback
+- RequestBody
+- MediaTypeMap
+- MediaType
+- Example
+- Encoding
+- Header
+- ResponsesMap
+- Response
+- Link
+- Schema
+- Xml
+- SchemaProperties
+- DiscriminatorMapping
+- Discriminator
+- Components
+- NamedSchemas: mapOf('Schema')
+- NamedResponses: mapOf('Response')
+- NamedParameters: mapOf('Parameter')
+- NamedExamples: mapOf('Example')
+- NamedRequestBodies: mapOf('RequestBody')
+- NamedHeaders: mapOf('Header')
+- NamedSecuritySchemes: mapOf('SecurityScheme')
+- NamedLinks: mapOf('Link')
+- NamedCallbacks: mapOf('PathItem')
+- ImplicitFlow
+- PasswordFlow
+- ClientCredentials
+- AuthorizationCode
+- SecuritySchemeFlows
+- SecurityScheme
+- XCodeSample
+- WebhooksMap

--- a/docs/resources/rules/assertions.md
+++ b/docs/resources/rules/assertions.md
@@ -27,8 +27,8 @@ severity | `string` | The severity level of the problem if the assertion is fals
 enum | [`string`] | Asserts value is within a predefined list of values. See [enum example](#enum-example).
 pattern | `string` | Asserts value matches a regex pattern. See [regex pattern example](#pattern-example).
 casing | `string` | Asserts a casing style from this possible list: `camelCase`, `kebab-case`, `snake_case`, `PascalCase`, `MACRO_CASE`, `COBOL-CASE`, `flatcase`. See [casing example](#casing-example).
-mutuallyExclusive | [`string`] | Asserts list of properties (key names only) are mutually exclusive. Use `$keys` in the `on` when this is enabled (for example, `Operation.$keys`). See [mutuallyExclusive example](#mutuallyexclusive-example).
-mutuallyRequired | [`string`] | Asserts list of properties (key names only) are mutually required. Use `$keys` in the `on` when this is enabled (for example, `Operation.$keys`). See [mutuallyRequired example](#mutuallyrequired-example).
+mutuallyExclusive | [`string`] | Asserts list of properties (key names only) are mutually exclusive. See [mutuallyExclusive example](#mutuallyexclusive-example).
+mutuallyRequired | [`string`] | Asserts list of properties (key names only) are mutually required. See [mutuallyRequired example](#mutuallyrequired-example).
 required | [`string`] | Asserts all listed values are defined. See [required example](#required-example).
 disallowed | [`string`] | Asserts all listed values are not defined. See [disallowed example](#disallowed-example).
 defined | `boolean` | Asserts a property is defined. See [defined example](#defined-example).
@@ -325,7 +325,7 @@ lint:
   rules:
     assertions:
       - subject: Operation
-        message: x-codeSamples and x-internal must not be defined
+        message: x-code-samples and x-internal must not be defined
         severity: error
         disallowed:
           - x-code-samples

--- a/docs/resources/rules/assertions.md
+++ b/docs/resources/rules/assertions.md
@@ -165,8 +165,8 @@ To restrict the evaluation, use the context feature to limit where context is us
 - context:
     - type: Operation
       matchParentKeys: [put]
-    - type: ResponsesMap
-      matchParentKeys: [201, 200]
+    - type: Response
+      matchParentKeys: ['201', '200']
   subject: MediaTypeMap
   disallowed: ['application/pdf']
 ```
@@ -269,7 +269,7 @@ This assertion runs only on node's keys.
 lint:
   rules:
     assertions:
-      - subject: Response
+      - subject: SchemaProperties
         message: The created_at and updated_at properties are mutually required
         severity: error
         mutuallyRequired:
@@ -283,7 +283,7 @@ The following example asserts that when `PUT` requests have either `200` or `201
 lint:
   rules:
     assertions:
-      - subject: ResponseMap
+      - subject: ResponsesMap
         context:
           - type: Operation
             matchParentKeys:

--- a/docs/resources/rules/assertions.md
+++ b/docs/resources/rules/assertions.md
@@ -36,7 +36,6 @@ undefined | `boolean` | Asserts a property is undefined. See [undefined example]
 nonEmpty | `boolean` | Asserts a property is not empty. See [nonEmpty example](#nonempty-example).
 minLength | `integer` | Asserts a minimum length (inclusive) of a string or list (array). See [minLength example](#minlength-example).
 maxLength | `integer` | Asserts a maximum length (exclusive) of a string or list (array). See [maxLength example](#maxlength-example).
-sortOrder | `string` |  Asserts values are sorted in ascending or descending order using one of these possible values: `asc` or `desc`. Asserts either sort order to a list (array) of strings or a collection of objects by one of the object's `property` values (the `property` is **REQUIRED** when sorting a collection of objects). See [sortOrder example](#sortorder-example).
 
 ## Context object
 
@@ -409,71 +408,11 @@ lint:
         maxLength: 20
 ```
 
-### `sortOrder` example
-
-Sort order can be applied on lists (arrays) of strings or lists of objects (collections).
-
-The following example asserts that the status schema's enum list is in alphabetical order.
-
-```yaml
-lint:
-  rules:
-    assertions:
-      - subject: Schema
-        property: enum
-        context:
-          - type: Schema
-            matchParentKeys: 
-              - status
-        message: The status enums should be in alphabetical order
-        suggest:
-          - alphabetize the list of status enums
-        severity: error
-        sortOrder: asc
-```
-
-The following example asserts the tag names (tags are a collection) are sorted in alphabetical order.
-
-The `property` field is **REQUIRED** to assert sort order on collections based on that property's value for the given subject. 
-
-```yaml
-lint:
-  rules:
-    assertions:
-      - subject: Tag
-        property: name
-        message: Tags should be ordered by name in alphabetical order
-        severity: error
-        sortOrder: asc
-```
-
 ## OpenAPI node types
 
 Redocly defines a type tree based on the document type.
 OpenAPI 2.0 has one type tree.
 OpenAPI 3.0 and OpenAPI 3.1 share a type tree.
-
-Node types are traversed using dot notation.
-
-The following example shows ways to traverse to the equivalent destination.
-One starts from the definition root into the info description.
-The other starts from the info section.
-
-```yaml Traversal from DefinitionRoot object type
-lint:
-  rules:
-    assertions:
-      - on:
-        - DefinitionRoot.info.description
-```
-
-```yaml Traversal from Info object type
-lint:
-  rules:
-    assertions:
-      - on:
-        - Info.description
-```
 
 ### List of OpenAPI types
 


### PR DESCRIPTION
## What/Why/How?

Add docs for the assertions feature. A few notes:
- I did not try out the feature yet.
- There are "TODO"s inside of the docs. Please look at the PR and find/comment.
- I omitted the `sortOrder` for now and would like to discuss it a bit further.
- In code: rename `description` to `message` for consistency with the naming throughout OpenAPI cli.
- In code: I think we should add support for `suggest` too (like we have that support in our built-in rules as well as custom rules).

This moves the bulk of the assertions docs to a stand-alone page.

In general, each rule should have its own page, but that will take a good deal of time to set up. There is no way this content can go inside of the built-in rules page, so instead I added a link to it from there.

### TODO

- [x] Add `sortOrder` docs
- [x] Add `suggest` to docs
- [x] Add OpenAPI node types section
- [x] Remove `length` from docs
- [ ] Check examples

## Reference

https://github.com/Redocly/openapi-cli/pull/489

## Testing

TODO

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
