### PR TITLE
fix: remove-unused-components strips remotely referenced components

### DIFF
--- a/__tests__/bundle/bundle-remove-unused-components/oas2/openapi.yaml
+++ b/__tests__/bundle/bundle-remove-unused-components/oas2/openapi.yaml
@@ -20,6 +20,9 @@ paths:
           x-internal: true
           schema:
             $ref: '#/definitions/MediaListResponse'
+        '401':
+          schema:
+            $ref: 'ref.yaml'
 parameters:
   AccountId:
     description: The account ID

--- a/__tests__/bundle/bundle-remove-unused-components/oas2/ref.yaml
+++ b/__tests__/bundle/bundle-remove-unused-components/oas2/ref.yaml
@@ -1,0 +1,3 @@
+{
+  "type": "string"
+}

--- a/__tests__/bundle/bundle-remove-unused-components/oas2/remove-unused-components-snapshot.js
+++ b/__tests__/bundle/bundle-remove-unused-components/oas2/remove-unused-components-snapshot.js
@@ -5,7 +5,14 @@ swagger: '2.0'
 host: api.instagram.com
 paths:
   /locations/{location-id}:
-    post: {}
+    post:
+      responses:
+        '401':
+          schema:
+            $ref: '#/definitions/ref'
+definitions:
+  ref:
+    type: string
 
 bundling ./openapi.yaml...
 📦 Created a bundle for ./openapi.yaml at stdout <test>ms.

--- a/__tests__/bundle/bundle-remove-unused-components/oas3/openapi.yaml
+++ b/__tests__/bundle/bundle-remove-unused-components/oas3/openapi.yaml
@@ -29,6 +29,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Order'
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: 'ref.yaml'
 components:
   parameters:
     x:

--- a/__tests__/bundle/bundle-remove-unused-components/oas3/ref.yaml
+++ b/__tests__/bundle/bundle-remove-unused-components/oas3/ref.yaml
@@ -1,0 +1,3 @@
+{
+  "type": "string"
+}

--- a/__tests__/bundle/bundle-remove-unused-components/oas3/remove-unused-components-snapshot.js
+++ b/__tests__/bundle/bundle-remove-unused-components/oas3/remove-unused-components-snapshot.js
@@ -6,6 +6,16 @@ paths:
   /store/order:
     post:
       operationId: storeOrder
+      responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ref'
+components:
+  schemas:
+    ref:
+      type: string
 
 bundling ./openapi.yaml...
 📦 Created a bundle for ./openapi.yaml at stdout <test>ms.

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -1,5 +1,5 @@
 import isEqual = require('lodash.isequal');
-import { BaseResolver, resolveDocument, Document, ResolvedRefMap } from './resolve';
+import { BaseResolver, resolveDocument, Document, ResolvedRefMap, makeRefId } from './resolve';
 import { Oas3Rule, normalizeVisitors, Oas3Visitor, Oas2Visitor } from './visitors';
 import { Oas3Types } from './types/oas3';
 import { Oas2Types } from './types/oas2';
@@ -231,7 +231,7 @@ function makeBundleVisitor(
             replaceRef(node, resolved, ctx);
           } else {
             node.$ref = saveComponent(componentType, resolved, ctx);
-            replaceInlineRef(node, resolved, ctx);
+            resolveBundledComponent(node, resolved, ctx);
           }
         }
       },
@@ -269,8 +269,8 @@ function makeBundleVisitor(
     };
   }
 
-  function replaceInlineRef(node: OasRef, resolved: ResolveResult<any>, ctx: UserContext) {
-    const newRefId = ctx.location.source.absoluteRef + '::' + node.$ref;
+  function resolveBundledComponent(node: OasRef, resolved: ResolveResult<any>, ctx: UserContext) {
+    const newRefId = makeRefId(ctx.location.source.absoluteRef, node.$ref)
     resolvedRefMap.set(newRefId, {
       document: rootDocument,
       isRemote: false,

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -74,6 +74,10 @@ export type Document = {
   parsed: any;
 };
 
+export function makeRefId(absoluteRef: string, pointer: string) {
+  return absoluteRef + '::' + pointer;
+}
+
 export function makeDocumentFromString(sourceString: string, absoluteRef: string) {
   const source = new Source(absoluteRef, sourceString);
   try {

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -327,10 +327,8 @@ export async function resolveDocument(opts: {
           document: undefined,
           error: error,
         };
-
-        const refId = document.source.absoluteRef + '::' + ref.$ref;
+        const refId = makeRefId(document.source.absoluteRef, ref.$ref);
         resolvedRefMap.set(refId, resolvedRef);
-
         return resolvedRef;
       }
 
@@ -371,13 +369,11 @@ export async function resolveDocument(opts: {
 
       resolvedRef.node = target;
       resolvedRef.document = targetDoc;
-      const refId = document.source.absoluteRef + '::' + ref.$ref;
-
+      const refId = makeRefId(document.source.absoluteRef, ref.$ref);
       if (resolvedRef.document && isRef(target)) {
         resolvedRef = await followRef(resolvedRef.document, target, pushRef(refStack, target));
       }
       resolvedRefMap.set(refId, resolvedRef);
-
       return { ...resolvedRef };
     }
   }

--- a/packages/core/src/rules/oas2/remove-unused-components.ts
+++ b/packages/core/src/rules/oas2/remove-unused-components.ts
@@ -15,16 +15,18 @@ export const RemoveUnusedComponents: Oas2Rule = () => {
   }
 
   return {
-    ref(ref, { type, resolve, key }) {
-      if (
-        ['Schema', 'Parameter', 'Response', 'SecurityScheme'].includes(type.name)
-      ) {
-        const resolvedRef = resolve(ref);
-        if (!resolvedRef.location) return;
-        components.set(resolvedRef.location.absolutePointer, {
-          used: true,
-          name: key.toString(),
-        });
+    ref: {
+      leave(ref, { type, resolve, key }) {
+        if (
+          ['Schema', 'Parameter', 'Response', 'SecurityScheme'].includes(type.name)
+        ) {
+          const resolvedRef = resolve(ref);
+          if (!resolvedRef.location) return;
+          components.set(resolvedRef.location.absolutePointer, {
+            used: true,
+            name: key.toString(),
+          });
+        }
       }
     },
     DefinitionRoot: {

--- a/packages/core/src/rules/oas3/remove-unused-components.ts
+++ b/packages/core/src/rules/oas3/remove-unused-components.ts
@@ -15,16 +15,18 @@ export const RemoveUnusedComponents: Oas3Rule = () => {
   }
 
   return {
-    ref(ref, { type, resolve, key }) {
-      if (
-        ['Schema', 'Header', 'Parameter', 'Response', 'Example', 'RequestBody'].includes(type.name)
-      ) {
-        const resolvedRef = resolve(ref);
-        if (!resolvedRef.location) return;
-        components.set(resolvedRef.location.absolutePointer, {
-          used: true,
-          name: key.toString(),
-        });
+    ref: {
+      leave(ref, { type, resolve, key }) {
+        if (
+          ['Schema', 'Header', 'Parameter', 'Response', 'Example', 'RequestBody'].includes(type.name)
+        ) {
+          const resolvedRef = resolve(ref);
+          if (!resolvedRef.location) return;
+          components.set(resolvedRef.location.absolutePointer, {
+            used: true,
+            name: key.toString(),
+          });
+        }
       }
     },
     DefinitionRoot: {

--- a/packages/core/src/walk.ts
+++ b/packages/core/src/walk.ts
@@ -7,7 +7,7 @@ import {
   VisitFunction,
 } from './visitors';
 
-import { ResolvedRefMap, Document, ResolveError, YamlParseError, Source } from './resolve';
+import { ResolvedRefMap, Document, ResolveError, YamlParseError, Source, makeRefId } from './resolve';
 import { pushStack, popStack } from './utils';
 import { OasVersion } from './oas-types';
 import { NormalizedNodeType, isNamedType } from './types';
@@ -370,10 +370,8 @@ export function walkDocument<T>(opts: {
       from: string = currentLocation.source.absoluteRef,
     ): ResolveResult<T> {
       if (!isRef(ref)) return { location, node: ref };
-      const refId = from + '::' + ref.$ref;
-
+      const refId = makeRefId(from, ref.$ref);
       const resolvedRef = resolvedRefMap.get(refId);
-
       if (!resolvedRef) {
         return {
           location: undefined,


### PR DESCRIPTION
## What/Why/How?
Closes #504  
## Check yourself
- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security
- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
