### PR TITLE
fix: oauth2-redirect.html is absent when served by preview-docs command #509

### DIFF
--- a/packages/cli/src/commands/preview-docs/preview-server/oauth2-redirect.html
+++ b/packages/cli/src/commands/preview-docs/preview-server/oauth2-redirect.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no" />
+    <title>Redocly Reference Docs: OAuth2 Redirect</title>
+    <style>
+      .user-info {
+        margin: 150px auto auto;
+        width: 50%;
+        background-color: whitesmoke;
+        padding: 20px;
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <script src="https://cdn.jsdelivr.net/npm/@redocly/reference-docs@latest/dist/oauth2-redirect.js"></script>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+  </body>
+</html>

--- a/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
+++ b/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
@@ -13,7 +13,6 @@ function getPageHTML(
   redocOptions: object = {},
   useRedocPro: boolean,
   wsPort: number,
-  oauth = false,
 ) {
   let templateSrc = readFileSync(htmlTemplate, 'utf-8');
 
@@ -37,11 +36,6 @@ function getPageHTML(
       ? 'https://cdn.jsdelivr.net/npm/@redocly/reference-docs@latest/dist/redocly-reference-docs.min.js'
       : 'https://cdn.jsdelivr.net/npm/redoc@latest/bundles/redoc.standalone.js'
   }"></script>
-  ${
-    useRedocPro && oauth
-      ? `<script src="https://cdn.jsdelivr.net/npm/@redocly/reference-docs@latest/dist/oauth2-redirect.js"></script>`
-      : ''
-  }
 `,
     redocHTML: `
   <div id="redoc"></div>
@@ -70,17 +64,10 @@ export default async function startPreviewServer(
   const handler = async (request: IncomingMessage, response: any) => {
     console.time(colorette.dim(`GET ${request.url}`));
     const { htmlTemplate } = getOptions() || {};
-    const isOAuthRedirect = request.url?.endsWith('/oauth2-redirect.html');
 
-    if (request.url?.endsWith('/') || path.extname(request.url!) === '' || isOAuthRedirect) {
+    if (request.url?.endsWith('/') || path.extname(request.url!) === '') {
       respondWithGzip(
-        getPageHTML(
-          htmlTemplate || defaultTemplate,
-          getOptions(),
-          useRedocPro,
-          wsPort,
-          isOAuthRedirect,
-        ),
+        getPageHTML(htmlTemplate || defaultTemplate, getOptions(), useRedocPro, wsPort),
         request,
         response,
         {
@@ -115,6 +102,7 @@ export default async function startPreviewServer(
         // @ts-ignore
         {
           '/hot.js': path.join(__dirname, 'hot.js'),
+          '/oauth2-redirect.html': path.join(__dirname, 'oauth2-redirect.html'),
           '/simplewebsocket.min.js': require.resolve('simple-websocket/simplewebsocket.min.js'),
         }[request.url || ''] ||
         path.resolve(htmlTemplate ? path.dirname(htmlTemplate) : process.cwd(), `.${request.url}`);

--- a/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
+++ b/packages/cli/src/commands/preview-docs/preview-server/preview-server.ts
@@ -13,6 +13,7 @@ function getPageHTML(
   redocOptions: object = {},
   useRedocPro: boolean,
   wsPort: number,
+  oauth = false,
 ) {
   let templateSrc = readFileSync(htmlTemplate, 'utf-8');
 
@@ -36,6 +37,11 @@ function getPageHTML(
       ? 'https://cdn.jsdelivr.net/npm/@redocly/reference-docs@latest/dist/redocly-reference-docs.min.js'
       : 'https://cdn.jsdelivr.net/npm/redoc@latest/bundles/redoc.standalone.js'
   }"></script>
+  ${
+    useRedocPro && oauth
+      ? `<script src="https://cdn.jsdelivr.net/npm/@redocly/reference-docs@latest/dist/oauth2-redirect.js"></script>`
+      : ''
+  }
 `,
     redocHTML: `
   <div id="redoc"></div>
@@ -64,10 +70,17 @@ export default async function startPreviewServer(
   const handler = async (request: IncomingMessage, response: any) => {
     console.time(colorette.dim(`GET ${request.url}`));
     const { htmlTemplate } = getOptions() || {};
+    const isOAuthRedirect = request.url?.endsWith('/oauth2-redirect.html');
 
-    if (request.url?.endsWith('/') || path.extname(request.url!) === '') {
+    if (request.url?.endsWith('/') || path.extname(request.url!) === '' || isOAuthRedirect) {
       respondWithGzip(
-        getPageHTML(htmlTemplate || defaultTemplate, getOptions(), useRedocPro, wsPort),
+        getPageHTML(
+          htmlTemplate || defaultTemplate,
+          getOptions(),
+          useRedocPro,
+          wsPort,
+          isOAuthRedirect,
+        ),
         request,
         response,
         {


### PR DESCRIPTION
## What/Why/How?
fix: oauth2-redirect.html is absent when served by preview-docs command #509
## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
