### PR TITLE
feat: introduce redocly.yaml

### DIFF
--- a/packages/core/src/config/__tests__/load.test.ts
+++ b/packages/core/src/config/__tests__/load.test.ts
@@ -1,5 +1,7 @@
-import { loadConfig } from '../load';
+import { loadConfig, findConfig } from '../load';
 import { RedoclyClient } from '../../redocly';
+
+const fs = require('fs')
 
 describe('loadConfig', () => {
   it('should resolve config http header by US region', async () => {
@@ -31,5 +33,32 @@ describe('loadConfig', () => {
       "envVariable": undefined,
       "value": "accessToken"
     }]);
+  });
+});
+
+describe('findConfig', () => {
+  it('should find redocly.yaml', async () => {
+    jest.spyOn(fs, 'existsSync').mockImplementation(
+      name => name === 'redocly.yaml'
+    );
+    const configName = findConfig();
+    expect(configName).toStrictEqual('redocly.yaml');
+  });
+  it('should find .redocly.yaml', async () => {
+    jest.spyOn(fs, 'existsSync').mockImplementation(
+      name => name === '.redocly.yaml'
+    );
+    const configName = findConfig();
+    expect(configName).toStrictEqual('.redocly.yaml');
+  });
+  it('should throw an error when found multiple config files', async () => {
+    jest.spyOn(fs, 'existsSync').mockImplementation(
+      name => name === 'redocly.yaml' || name === '.redocly.yaml'
+    );
+    expect(findConfig).toThrow(`
+      Multiple configuration files are not allowed. 
+      Found the following files: redocly.yaml, .redocly.yaml. 
+      Please use 'redocly.yaml' instead.
+    `);
   });
 });

--- a/packages/core/src/config/__tests__/load.test.ts
+++ b/packages/core/src/config/__tests__/load.test.ts
@@ -1,60 +1,65 @@
 import { loadConfig, findConfig } from '../load';
 import { RedoclyClient } from '../../redocly';
 
-const fs = require('fs')
+const fs = require('fs');
 
 describe('loadConfig', () => {
   it('should resolve config http header by US region', async () => {
-    jest.spyOn(RedoclyClient.prototype, 'getTokens').mockImplementation(
-      () => Promise.resolve([{ region: 'us', token: "accessToken", valid: true }])
-    );
+    jest
+      .spyOn(RedoclyClient.prototype, 'getTokens')
+      .mockImplementation(() =>
+        Promise.resolve([{ region: 'us', token: 'accessToken', valid: true }]),
+      );
     const config = await loadConfig();
-    expect(config.resolve.http.headers).toStrictEqual([{
-      "matches": 'https://api.redoc.ly/registry/**',
-      "name": "Authorization",
-      "envVariable": undefined,
-      "value": "accessToken"
-    }, {
-      "matches": 'https://api.redocly.com/registry/**',
-      "name": "Authorization",
-      "envVariable": undefined,
-      "value": "accessToken"
-    }]);
+    expect(config.resolve.http.headers).toStrictEqual([
+      {
+        matches: 'https://api.redoc.ly/registry/**',
+        name: 'Authorization',
+        envVariable: undefined,
+        value: 'accessToken',
+      },
+      {
+        matches: 'https://api.redocly.com/registry/**',
+        name: 'Authorization',
+        envVariable: undefined,
+        value: 'accessToken',
+      },
+    ]);
   });
 
   it('should resolve config http header by EU region', async () => {
-    jest.spyOn(RedoclyClient.prototype, 'getTokens').mockImplementation(
-      () => Promise.resolve([{ region: 'eu', token: "accessToken", valid: true }])
-    );
+    jest
+      .spyOn(RedoclyClient.prototype, 'getTokens')
+      .mockImplementation(() =>
+        Promise.resolve([{ region: 'eu', token: 'accessToken', valid: true }]),
+      );
     const config = await loadConfig();
-    expect(config.resolve.http.headers).toStrictEqual([{
-      "matches": 'https://api.eu.redocly.com/registry/**',
-      "name": "Authorization",
-      "envVariable": undefined,
-      "value": "accessToken"
-    }]);
+    expect(config.resolve.http.headers).toStrictEqual([
+      {
+        matches: 'https://api.eu.redocly.com/registry/**',
+        name: 'Authorization',
+        envVariable: undefined,
+        value: 'accessToken',
+      },
+    ]);
   });
 });
 
 describe('findConfig', () => {
   it('should find redocly.yaml', async () => {
-    jest.spyOn(fs, 'existsSync').mockImplementation(
-      name => name === 'redocly.yaml'
-    );
+    jest.spyOn(fs, 'existsSync').mockImplementation((name) => name === 'redocly.yaml');
     const configName = findConfig();
     expect(configName).toStrictEqual('redocly.yaml');
   });
   it('should find .redocly.yaml', async () => {
-    jest.spyOn(fs, 'existsSync').mockImplementation(
-      name => name === '.redocly.yaml'
-    );
+    jest.spyOn(fs, 'existsSync').mockImplementation((name) => name === '.redocly.yaml');
     const configName = findConfig();
     expect(configName).toStrictEqual('.redocly.yaml');
   });
   it('should throw an error when found multiple config files', async () => {
-    jest.spyOn(fs, 'existsSync').mockImplementation(
-      name => name === 'redocly.yaml' || name === '.redocly.yaml'
-    );
+    jest
+      .spyOn(fs, 'existsSync')
+      .mockImplementation((name) => name === 'redocly.yaml' || name === '.redocly.yaml');
     expect(findConfig).toThrow(`
       Multiple configuration files are not allowed. 
       Found the following files: redocly.yaml, .redocly.yaml. 

--- a/packages/core/src/config/load.ts
+++ b/packages/core/src/config/load.ts
@@ -61,11 +61,22 @@ export async function loadConfig(configPath?: string, customExtends?: string[]):
   );
 }
 
-function findConfig() {
-  if (fs.existsSync('.redocly.yaml')) {
-    return '.redocly.yaml';
-  } else if (fs.existsSync('.redocly.yml')) {
-    return '.redocly.yml';
+export function findConfig(): string | undefined {
+  const possibleConfigNames = [
+    'redocly.yaml',
+    'redocly.yml',
+    '.redocly.yaml',
+    '.redocly.yml',
+  ];
+  const existingConfigFiles = possibleConfigNames
+    .map((name) => fs.existsSync(name) && name)
+    .filter(Boolean) as Array<string | never>;
+  if (existingConfigFiles.length > 1) {
+    throw new Error(`
+      Multiple configuration files are not allowed. 
+      Found the following files: ${existingConfigFiles.join(', ')}. 
+      Please use 'redocly.yaml' instead.
+    `);
   }
-  return undefined;
+  return existingConfigFiles[0];
 }

--- a/packages/core/src/config/load.ts
+++ b/packages/core/src/config/load.ts
@@ -61,7 +61,7 @@ export async function loadConfig(configPath?: string, customExtends?: string[]):
   );
 }
 
-const CONFIG_FILE_NAMES = ['redocly.yaml', 'redocly.yml', '.redocly.yaml', '.redocly.yml'];
+export const CONFIG_FILE_NAMES = ['redocly.yaml', 'redocly.yml', '.redocly.yaml', '.redocly.yml'];
 
 export function findConfig(): string | undefined {
   if (!fs.hasOwnProperty('existsSync')) return;

--- a/packages/core/src/config/load.ts
+++ b/packages/core/src/config/load.ts
@@ -61,16 +61,14 @@ export async function loadConfig(configPath?: string, customExtends?: string[]):
   );
 }
 
+const CONFIG_FILE_NAMES = ['redocly.yaml', 'redocly.yml', '.redocly.yaml', '.redocly.yml'];
+
 export function findConfig(): string | undefined {
-  const possibleConfigNames = [
-    'redocly.yaml',
-    'redocly.yml',
-    '.redocly.yaml',
-    '.redocly.yml',
-  ];
-  const existingConfigFiles = possibleConfigNames
-    .map((name) => fs.existsSync(name) && name)
-    .filter(Boolean) as Array<string | never>;
+  if (!fs.hasOwnProperty('existsSync')) return;
+
+  const existingConfigFiles = CONFIG_FILE_NAMES.map((name) => fs.existsSync(name) && name).filter(
+    Boolean,
+  ) as Array<string | never>;
   if (existingConfigFiles.length > 1) {
     throw new Error(`
       Multiple configuration files are not allowed. 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,7 +22,7 @@ export { normalizeTypes } from './types';
 export { Stats } from './rules/other/stats';
 
 export { Config, LintConfig, RawConfig, IGNORE_FILE, Region } from './config/config';
-export { loadConfig } from './config/load';
+export { loadConfig, findConfig, CONFIG_FILE_NAMES } from './config/load';
 export { RedoclyClient } from './redocly';
 export {
   Source,


### PR DESCRIPTION
## What/Why/How?

[Pitch: change .redocly.yaml config structure](https://intranet.redoc.ly/roadmap/tooling/2022-02/redocly-yaml/)
Introduces `redocly.yaml` file name.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
