### PR TITLE
chore: add getAllTokens method to RedoclyClient

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -130,6 +130,7 @@ export const DOMAINS: { [region in Region]: string } = {
   us: 'redoc.ly',
   eu: 'eu.redocly.com',
 };
+export const AVAILABLE_REGIONS = Object.keys(DOMAINS) as Region[];
 
 // FIXME: temporary fix for our lab environments
 if (REDOCLY_DOMAIN?.endsWith('.redocly.host')) {

--- a/packages/core/src/redocly/__tests__/redocly-client.test.ts
+++ b/packages/core/src/redocly/__tests__/redocly-client.test.ts
@@ -50,6 +50,19 @@ describe('RedoclyClient', () => {
     expect(client.getRegion()).toBe('eu');
   });
 
+  it('should resolve all tokens', async () => {
+    let spy = jest.spyOn(RedoclyClient.prototype, 'readCredentialsFile').mockImplementation(() => {
+      return { us: "accessToken", eu: "eu-accessToken" };
+    });
+    const client = new RedoclyClient();
+    const tokens = client.getAllTokens();
+    expect(tokens).toStrictEqual([
+      { region: 'us', token: 'accessToken' },
+      { region: 'eu', token: 'eu-accessToken' }
+    ]);
+    spy.mockRestore();
+  });
+
   it('should resolve valid tokens data', async () => {
     let spy = jest.spyOn(RedoclyClient.prototype, 'readCredentialsFile').mockImplementation(() => {
       return { us: "accessToken", eu: "eu-accessToken" }

--- a/packages/core/src/redocly/__tests__/redocly-client.test.ts
+++ b/packages/core/src/redocly/__tests__/redocly-client.test.ts
@@ -52,7 +52,7 @@ describe('RedoclyClient', () => {
 
   it('should resolve all tokens', async () => {
     let spy = jest.spyOn(RedoclyClient.prototype, 'readCredentialsFile').mockImplementation(() => {
-      return { us: "accessToken", eu: "eu-accessToken" };
+      return { token: "accessToken", us: "accessToken", eu: "eu-accessToken" };
     });
     const client = new RedoclyClient();
     const tokens = client.getAllTokens();

--- a/packages/core/src/redocly/index.ts
+++ b/packages/core/src/redocly/index.ts
@@ -93,9 +93,9 @@ export class RedoclyClient {
   }
 
   getAllTokens (): RegionalToken[] {
-    return Object.entries(this.accessTokens).map(([key, value]) => {
-      return { region: key as Region, token: value };
-    });
+    return Object.entries(this.accessTokens).map(([key, value]) =>
+      ({ region: key as Region, token: value })
+    );
   }
 
   async getValidTokens(): Promise<RegionalTokenWithValidity[]> {

--- a/packages/core/src/redocly/index.ts
+++ b/packages/core/src/redocly/index.ts
@@ -3,7 +3,7 @@ import { resolve } from 'path';
 import { homedir } from 'os';
 import { red, green, gray, yellow } from 'colorette';
 import { RegistryApi } from './registry-api';
-import { AccessTokens, DEFAULT_REGION, DOMAINS, Region } from '../config/config';
+import { AccessTokens, DEFAULT_REGION, DOMAINS, Region, AVAILABLE_REGIONS } from '../config/config';
 import { RegionalToken, RegionalTokenWithValidity } from './redocly-client-types';
 import { isNotEmptyObject } from '../utils';
 
@@ -33,7 +33,7 @@ export class RedoclyClient {
     }
 
     if (process.env.REDOCLY_DOMAIN) {
-      return (Object.keys(DOMAINS).find(
+      return (AVAILABLE_REGIONS.find(
         (region) => DOMAINS[region as Region] === process.env.REDOCLY_DOMAIN,
       ) || DEFAULT_REGION) as Region;
     }
@@ -93,8 +93,10 @@ export class RedoclyClient {
   }
 
   getAllTokens (): RegionalToken[] {
-    return Object.entries(this.accessTokens).map(([key, value]) =>
-      ({ region: key as Region, token: value })
+    return (<[Region, string][]>Object.entries(this.accessTokens)).filter(
+      ([region]) => AVAILABLE_REGIONS.includes(region)
+    ).map(
+      ([region, token]) => ({ region, token })
     );
   }
 

--- a/packages/core/src/redocly/redocly-client-types.ts
+++ b/packages/core/src/redocly/redocly-client-types.ts
@@ -1,0 +1,10 @@
+import { Region } from '../config/config';
+
+export interface RegionalToken {
+  region: Region;
+  token: string;
+}
+
+export interface RegionalTokenWithValidity extends RegionalToken {
+  valid: boolean;
+}


### PR DESCRIPTION
## What/Why/How?
Added `getAllTokens` method to `RedoclyClient` class to avoid code duplication of finding `.redocly-config.json` file, reading tokens from there and taking proper token field.
## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
