### PR TITLE
fix: detect parameters without schema or content fields

### DIFF
--- a/__tests__/lint/oas3.1-error/snapshot.js
+++ b/__tests__/lint/oas3.1-error/snapshot.js
@@ -5,7 +5,7 @@ exports[`E2E lint oas3.1-error 1`] = `
 validating /openapi.yaml...
 [1] openapi.yaml:1:1 at #/
 
-Must contain at least one of the following fields: path, components, webhooks.
+Must contain at least one of the following fields: paths, components, webhooks.
 
  1 | openapi: 3.1.0
    | ^^^^^^^^^^^^^^

--- a/packages/core/src/rules/common/__tests__/spec.test.ts
+++ b/packages/core/src/rules/common/__tests__/spec.test.ts
@@ -1,0 +1,62 @@
+import { outdent } from 'outdent';
+import { lintDocument } from '../../../lint';
+import { parseYamlToDocument, replaceSourceWithRef, makeConfig } from '../../../../__tests__/utils';
+import { BaseResolver } from '../../../resolve';
+
+describe('Oas3 spec', () => {
+  it('should report missing schema property', async () => {
+    const document = parseYamlToDocument(
+      outdent`
+      openapi: 3.0.0
+      paths:
+        '/test':
+          get:
+            summary: Gets a specific pet
+            parameters:
+            - name: petId
+              in: path
+            responses:
+              200:
+                description: Ok
+        `,
+      'foobar.yaml',
+    );
+
+    const results = await lintDocument({
+      externalRefResolver: new BaseResolver(),
+      document,
+      config: makeConfig({ 'spec': 'error' }),
+    });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "location": Array [
+            Object {
+              "pointer": "#/",
+              "reportOnKey": true,
+              "source": "foobar.yaml",
+            },
+          ],
+          "message": "The field \`info\` must be present on this level.",
+          "ruleId": "spec",
+          "severity": "error",
+          "suggest": Array [],
+        },
+        Object {
+          "location": Array [
+            Object {
+              "pointer": "#/paths/~1test/get/parameters/0",
+              "reportOnKey": true,
+              "source": "foobar.yaml",
+            },
+          ],
+          "message": "A parameter must contain either a \`schema\` property, or a \`content\` property, but not both.",
+          "ruleId": "spec",
+          "severity": "error",
+          "suggest": Array [],
+        },
+      ]
+    `);
+  });
+});

--- a/packages/core/src/rules/common/__tests__/spec.test.ts
+++ b/packages/core/src/rules/common/__tests__/spec.test.ts
@@ -51,7 +51,7 @@ describe('Oas3 spec', () => {
               "source": "foobar.yaml",
             },
           ],
-          "message": "A parameter must contain either a \`schema\` property, or a \`content\` property, but not both.",
+          "message": "Must contain at least one of the following fields: schema, content.",
           "ruleId": "spec",
           "severity": "error",
           "suggest": Array [],

--- a/packages/core/src/rules/common/spec.ts
+++ b/packages/core/src/rules/common/spec.ts
@@ -2,11 +2,11 @@ import type { Oas3Rule, Oas2Rule } from '../../visitors';
 import { isNamedType } from '../../types';
 import { oasTypeOf, matchesJsonSchemaType, getSuggest } from '../utils';
 import { isRef } from '../../ref-utils';
-import { isPlainObject, hasOneOfProperty } from '../../utils';
+import { isPlainObject } from '../../utils';
 
 export const OasSpec: Oas3Rule | Oas2Rule = () => {
   return {
-    any(node: any, { report, oasVersion, type, location, key, resolve, ignoreNextVisitorsOnNode } ) {
+    any(node: any, { report, type, location, key, resolve, ignoreNextVisitorsOnNode } ) {
       const nodeType = oasTypeOf(node);
 
       if (type.items) {
@@ -32,18 +32,6 @@ export const OasSpec: Oas3Rule | Oas2Rule = () => {
         if (!(node as object).hasOwnProperty(propName)) {
           report({
             message: `The field \`${propName}\` must be present on this level.`,
-            location: [{ reportOnKey: true }],
-          });
-        }
-      }
-
-      if (oasVersion !== 'oas2') {
-        if (
-          type.name === 'Parameter' &&
-          !hasOneOfProperty(node as object, ['schema', 'content'])
-        ) {
-          report({
-            message: `A parameter must contain either a \`schema\` property, or a \`content\` property, but not both.`,
             location: [{ reportOnKey: true }],
           });
         }
@@ -75,7 +63,7 @@ export const OasSpec: Oas3Rule | Oas2Rule = () => {
         }
         if (!hasProperty)
           report({
-            message: 'Must contain at least one of the following fields: path, components, webhooks.',
+            message: `Must contain at least one of the following fields: ${type.requiredOneOf?.join(', ')}.`,
             location: [{ reportOnKey: true }],
           });
       }

--- a/packages/core/src/rules/common/spec.ts
+++ b/packages/core/src/rules/common/spec.ts
@@ -53,8 +53,8 @@ export const OasSpec: Oas3Rule | Oas2Rule = () => {
       if (allowed && isPlainObject(node)) {
         for (const propName in node) {
           if (allowed.includes(propName) ||
-            (type.extensionsPrefix && propName.startsWith(type.extensionsPrefix)) ||
-            !Object.keys(type.properties).includes(propName)
+          (type.extensionsPrefix && propName.startsWith(type.extensionsPrefix)) ||
+          !Object.keys(type.properties).includes(propName)
           ) {
             continue;
           }

--- a/packages/core/src/rules/common/spec.ts
+++ b/packages/core/src/rules/common/spec.ts
@@ -53,8 +53,8 @@ export const OasSpec: Oas3Rule | Oas2Rule = () => {
       if (allowed && isPlainObject(node)) {
         for (const propName in node) {
           if (allowed.includes(propName) ||
-            (type.extensionsPrefix && propName.startsWith(type.extensionsPrefix)) ||
-            !Object.keys(type.properties).includes(propName)
+           (type.extensionsPrefix && propName.startsWith(type.extensionsPrefix)) ||
+           !Object.keys(type.properties).includes(propName)
           ) {
             continue;
           }

--- a/packages/core/src/rules/common/spec.ts
+++ b/packages/core/src/rules/common/spec.ts
@@ -40,7 +40,7 @@ export const OasSpec: Oas3Rule | Oas2Rule = () => {
       if (oasVersion !== 'oas2') {
         if (
           type.name === 'Parameter' &&
-          !hasOnePropNotSeveral(node as object, ['schema', 'content'])
+          !hasOneOfProperty(node as object, ['schema', 'content'])
         ) {
           report({
             message: `A parameter must contain either a \`schema\` property, or a \`content\` property, but not both.`,

--- a/packages/core/src/rules/common/spec.ts
+++ b/packages/core/src/rules/common/spec.ts
@@ -53,8 +53,8 @@ export const OasSpec: Oas3Rule | Oas2Rule = () => {
       if (allowed && isPlainObject(node)) {
         for (const propName in node) {
           if (allowed.includes(propName) ||
-          (type.extensionsPrefix && propName.startsWith(type.extensionsPrefix)) ||
-          !Object.keys(type.properties).includes(propName)
+            (type.extensionsPrefix && propName.startsWith(type.extensionsPrefix)) ||
+            !Object.keys(type.properties).includes(propName)
           ) {
             continue;
           }

--- a/packages/core/src/rules/common/spec.ts
+++ b/packages/core/src/rules/common/spec.ts
@@ -2,7 +2,7 @@ import type { Oas3Rule, Oas2Rule } from '../../visitors';
 import { isNamedType } from '../../types';
 import { oasTypeOf, matchesJsonSchemaType, getSuggest } from '../utils';
 import { isRef } from '../../ref-utils';
-import { isPlainObject, hasOnePropNotSeveral } from '../../utils';
+import { isPlainObject, hasOneOfProperty } from '../../utils';
 
 export const OasSpec: Oas3Rule | Oas2Rule = () => {
   return {

--- a/packages/core/src/types/oas3.ts
+++ b/packages/core/src/types/oas3.ts
@@ -136,6 +136,7 @@ const Parameter: NodeType = {
     content: 'MediaTypeMap',
   },
   required: ['name', 'in'],
+  requiredOneOf: ['schema', 'content']
 };
 
 const Callback = {

--- a/packages/core/src/types/oas3.ts
+++ b/packages/core/src/types/oas3.ts
@@ -136,7 +136,7 @@ const Parameter: NodeType = {
     content: 'MediaTypeMap',
   },
   required: ['name', 'in'],
-  requiredOneOf: ['schema', 'content']
+  requiredOneOf: ['schema', 'content'],
 };
 
 const Callback = {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -173,7 +173,7 @@ export function isNotEmptyObject(obj: any) {
   return !!obj && Object.keys(obj).length > 0;
 }
 
-export function hasOnePropNotSeveral(obj: object, props: Array<string>) {
+export function hasOneOfProperty(obj: object, props: Array<string>) {
   let count = 0;
   for (let i = 0; i < props.length; i++) {
     if (obj.hasOwnProperty(props[i])) {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -180,5 +180,5 @@ export function hasOnePropNotSeveral(obj: object, props: Array<string>) {
       count++;
     }
   }
-  return count === 1 ? true : false;
+  return count === 1;
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -172,13 +172,3 @@ export function isPathParameter(pathSegment: string) {
 export function isNotEmptyObject(obj: any) {
   return !!obj && Object.keys(obj).length > 0;
 }
-
-export function hasOneOfProperty(obj: object, props: Array<string>) {
-  let count = 0;
-  for (let i = 0; i < props.length; i++) {
-    if (obj.hasOwnProperty(props[i])) {
-      count++;
-    }
-  }
-  return count === 1;
-}

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -172,3 +172,13 @@ export function isPathParameter(pathSegment: string) {
 export function isNotEmptyObject(obj: any) {
   return !!obj && Object.keys(obj).length > 0;
 }
+
+export function hasOnePropNotSeveral(obj: object, props: Array<string>) {
+  let count = 0;
+  for (let i = 0; i < props.length; i++) {
+    if (obj.hasOwnProperty(props[i])) {
+      count++;
+    }
+  }
+  return count === 1 ? true : false;
+}


### PR DESCRIPTION
## What/Why/How?
OpenAPI CLI should detect Parameters without schema or content fields while the OpenAPI specification states that one of these fields MUST be specified.
<img width="919" alt="image" src="https://user-images.githubusercontent.com/54616703/157288114-3d105229-55e7-49d7-946f-d10e410c673d.png">

## Reference
Fixes #568 
Fixes #570 

## Testing
Tested locally

## Screenshots (optional)
N/a

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
