### PR TITLE
fix: use correct domain when logging to labs

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -130,7 +130,6 @@ export const DOMAINS: { [region in Region]: string } = {
   us: 'redocly.com',
   eu: 'eu.redocly.com',
 };
-export const AVAILABLE_REGIONS = Object.keys(DOMAINS) as Region[];
 
 // FIXME: temporary fix for our lab environments
 if (REDOCLY_DOMAIN?.endsWith('.redocly.host')) {
@@ -139,6 +138,7 @@ if (REDOCLY_DOMAIN?.endsWith('.redocly.host')) {
 if (REDOCLY_DOMAIN === 'redoc.online') {
   DOMAINS[REDOCLY_DOMAIN as Region] = REDOCLY_DOMAIN;
 }
+export const AVAILABLE_REGIONS = Object.keys(DOMAINS) as Region[];
 
 export type RawConfig = {
   referenceDocs?: any;


### PR DESCRIPTION
## What/Why/How?

At the moment, when trying to log in to a lab environment, the request is always sent to the `api.redocly.com/registry`. It happens because there are no 'lab' regions in `ALLOWED_DOMAINS` so OpenapiCLI uses default 'us' region.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
