### PR TITLE
fix: update .redocly.yaml types

### DIFF
--- a/packages/core/src/__tests__/lint.test.ts
+++ b/packages/core/src/__tests__/lint.test.ts
@@ -46,7 +46,7 @@ describe('lint', () => {
   it('lintConfig should work', async () => {
     const document = parseYamlToDocument(
       outdent`
-      apiDefinitions: error string
+      apis: error string
       lint:
         plugins:
           - './local-plugin.js'
@@ -58,7 +58,7 @@ describe('lint', () => {
           no-invalid-media-type-examples: error
           path-http-verbs-order: error
           boolean-parameter-prefixes: off
-      referenceDocs:
+      features.openapi:
         showConsole: true
         layout:
           scope: section
@@ -78,12 +78,12 @@ describe('lint', () => {
         Object {
           "location": Array [
             Object {
-              "pointer": "#/apiDefinitions",
+              "pointer": "#/apis",
               "reportOnKey": false,
               "source": "",
             },
           ],
-          "message": "Expected type \`object\` but got \`string\`.",
+          "message": "Expected type \`ConfigApis\` (object) but got \`string\`",
           "ruleId": "spec",
           "severity": "error",
           "suggest": Array [],
@@ -91,12 +91,46 @@ describe('lint', () => {
         Object {
           "location": Array [
             Object {
-              "pointer": "#/referenceDocs/layout",
+              "pointer": "#/features.openapi/layout",
               "reportOnKey": false,
               "source": "",
             },
           ],
           "message": "Expected type \`string\` but got \`object\`.",
+          "ruleId": "spec",
+          "severity": "error",
+          "suggest": Array [],
+        },
+      ]
+    `);
+  });
+
+  it("'plugins' shouldn't be allowed in 'apis' -> 'lint' field", async () => {
+    const document = parseYamlToDocument(
+      outdent`
+      apis: 
+        lint: 
+          plugins: 
+            - './local-plugin.js'
+      lint:
+        plugins:
+          - './local-plugin.js'
+      `,
+      '',
+    );
+    const results = await lintConfig({ document });
+
+    expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "location": Array [
+            Object {
+              "pointer": "#/apis/lint/plugins",
+              "reportOnKey": true,
+              "source": "",
+            },
+          ],
+          "message": "Property \`plugins\` is not expected here.",
           "ruleId": "spec",
           "severity": "error",
           "suggest": Array [],
@@ -140,7 +174,7 @@ describe('lint', () => {
     const results = await lintDocument({
       externalRefResolver: new BaseResolver(),
       document,
-      config: makeConfig({ spec: 'error', }),
+      config: makeConfig({ spec: 'error' }),
     });
 
     expect(replaceSourceWithRef(results)).toMatchInlineSnapshot(`Array []`);

--- a/packages/core/src/types/redocly-yaml.ts
+++ b/packages/core/src/types/redocly-yaml.ts
@@ -3,14 +3,24 @@ import { omitObjectProps, pickObjectProps } from '../utils';
 
 const ConfigRoot: NodeType = {
   properties: {
-    apiDefinitions: {
-      type: 'object',
-      properties: {},
-      additionalProperties: { properties: { type: 'string' } },
-    },
-    lint: 'ConfigLint',
-    referenceDocs: 'ConfigReferenceDocs',
+    organization: { type: 'string' },
+    apis: 'ConfigApis',
+    lint: 'RootConfigLint',
+    'features.openapi': 'ConfigReferenceDocs',
     'features.mockServer': 'ConfigMockServer',
+  },
+};
+
+const ConfigApis: NodeType = {
+  properties: {},
+  additionalProperties: 'ConfigApisProperties',
+};
+
+const ConfigApisProperties: NodeType = {
+  properties: {
+    root: { type: 'string' },
+    lint: 'ConfigLint',
+    'features.openapi': 'ConfigReferenceDocs',
   },
 };
 
@@ -27,10 +37,6 @@ const ConfigHTTP: NodeType = {
 
 const ConfigLint: NodeType = {
   properties: {
-    plugins: {
-      type: 'array',
-      items: { type: 'string' },
-    },
     extends: {
       type: 'array',
       items: {
@@ -55,6 +61,16 @@ const ConfigLint: NodeType = {
         http: 'ConfigHTTP',
       },
     },
+  },
+};
+
+const RootConfigLint: NodeType = {
+  properties: {
+    plugins: {
+      type: 'array',
+      items: { type: 'string' },
+    },
+    ...ConfigLint.properties,
   },
 };
 
@@ -562,6 +578,9 @@ const ConfigMockServer: NodeType = {
 
 export const ConfigTypes: Record<string, NodeType> = {
   ConfigRoot,
+  ConfigApis,
+  ConfigApisProperties,
+  RootConfigLint,
   ConfigLint,
   ConfigReferenceDocs,
   ConfigMockServer,


### PR DESCRIPTION
## What/Why/How?
Update types used to lint .redocly.yaml according to new config file structure
## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
