### PR TITLE
fix: additional properties warnings on allOf

### DIFF
--- a/packages/core/src/rules/ajv.ts
+++ b/packages/core/src/rules/ajv.ts
@@ -39,7 +39,10 @@ function getAjvValidator(
   disallowAdditionalProperties: boolean,
 ): ValidateFunction | undefined {
   const ajv = getAjv(resolve, disallowAdditionalProperties);
-
+  if (!ajv.opts.defaultAdditionalProperties !== disallowAdditionalProperties) {
+    schema = resolve(schema);
+    schema.additionalProperties = true;
+  }
   if (!ajv.getSchema(loc.absolutePointer)) {
     ajv.addSchema({ $id: loc.absolutePointer, ...schema }, loc.absolutePointer);
   }

--- a/packages/core/src/rules/oas3/no-invalid-media-type-examples.ts
+++ b/packages/core/src/rules/oas3/no-invalid-media-type-examples.ts
@@ -27,12 +27,14 @@ export const ValidContentExamples: Oas3Rule = (opts) => {
             location = isMultiple ? resolved.location.child('value') : resolved.location;
             example = resolved.node;
           }
+          
+          const hasAllof = !!resolve(mediaType.schema).node?.allOf;
           validateExample(
             isMultiple ? example.value : example,
             mediaType.schema!,
             location,
             ctx,
-            disallowAdditionalProperties,
+            hasAllof ? false : disallowAdditionalProperties
           );
         }
       },


### PR DESCRIPTION
## What/Why/How?
Allows `additionalProperties` on example linting inside `allOf` for `no-invalid-media-type-examples` rule.
This is done to fix #552 issue, where it mistakenly produced warnings for additional properties inside allOf.

## Reference
Closes #552 

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
