### PR TITLE
Feat: Skip decorator option for push command

### DIFF
--- a/docs/commands/push.md
+++ b/docs/commands/push.md
@@ -83,7 +83,7 @@ destination      | string    | Required. The location in the API registry where 
 --branch, -b    | string  | Optional. The branch where your API definition will be pushed or upserted. Default value is `main`.  |
 --help       | boolean | Optional. Help output for the command.  |
 --run-id       | string  | Optional. Specify the ID of the CI job that the current push will be associated with. See [the Run ID section](#run-id) for more information.  |
---skip-decorator | [string] | Optional. Ignore one or more decorators. See the [Skip decorator section](#skip-decorator)
+--skip-decorator | [string] | Optional. Ignore one or more decorators. See the [Skip decorator section](#skip-decorator) for usage examples.
 --upsert, -u | boolean | Optional. Upsert an API to the API registry. See [the Upsert an API with push section](#upsert-an-api-with-push) for more information.  |
 --version     | boolean | Optional. Show version number.  |
 --region,-r    | string | Optional. Specify which region to use when logging in. Supported values: `us`, `eu`. Default value is `us`. Read more about [configuring the region](../configuration/configuration-file.mdx#region).

--- a/docs/commands/push.md
+++ b/docs/commands/push.md
@@ -84,6 +84,7 @@ destination      | string    | Required. The location in the API registry where 
 --branch, -b    | string  | Optional. The branch where your API definition will be pushed or upserted. Default value is `main`.  |
 --help       | boolean | Optional. Help output for the command.  |
 --run-id       | string  | Optional. Specify the ID of the CI job that the current push will be associated with. See [the Run ID section](#run-id) for more information.  |
+--skip-decorator | [string] | Optional. Ignore certain decorators. See the [Skip preprocessor, rule, or decorator section](#skip-preprocessor-rule-or-decorator).
 --upsert, -u | boolean | Optional. Upsert an API to the API registry. See [the Upsert an API with push section](#upsert-an-api-with-push) for more information.  |
 --version     | boolean | Optional. Show version number.  |
 --region,-r    | string | Optional. Specify which region to use when logging in. Supported values: `us`, `eu`. Default value is `us`. Read more about [configuring the region](../configuration/configuration-file.mdx#region).
@@ -253,6 +254,14 @@ Below are possible use cases for the `--run-id` option:
 
 - CI/CD systems: group pushes from a single CI job together so that each push does not trigger separate reference docs/portals rebuild.
 - External systems: a parameter that can be used in reports, metrics, analytics to refer to a specific application service state.
+
+### Skip decorator
+
+You may want to skip specific decorators upon running the command.
+
+```bash Skip decorators
+openapi push openapi/petstore.yaml @openapi-org/petstore-api@v1 --skip-decorator=test/remove-internal-operations
+```
 
 
 ### Set up CI from Redocly Workflows

--- a/docs/commands/push.md
+++ b/docs/commands/push.md
@@ -253,7 +253,7 @@ Below are possible use cases for the `--run-id` option:
 
 You may want to skip specific decorators upon running the command.
 
-```bash Skip decorators
+```bash Skip a decorator
 openapi push openapi/petstore.yaml @openapi-org/petstore-api@v1 --skip-decorator=test/remove-internal-operations
 ```
 

--- a/docs/commands/push.md
+++ b/docs/commands/push.md
@@ -66,7 +66,6 @@ To authenticate to the API registry, you can use several approaches:
   - [GitHub Actions documentation](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets)
   - [Jenkins documentation](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#handling-credentials)
 
-
 ## Usage
 
 ```bash
@@ -84,11 +83,10 @@ destination      | string    | Required. The location in the API registry where 
 --branch, -b    | string  | Optional. The branch where your API definition will be pushed or upserted. Default value is `main`.  |
 --help       | boolean | Optional. Help output for the command.  |
 --run-id       | string  | Optional. Specify the ID of the CI job that the current push will be associated with. See [the Run ID section](#run-id) for more information.  |
---skip-decorator | [string] | Optional. Ignore certain decorators. See the [Skip preprocessor, rule, or decorator section](#skip-preprocessor-rule-or-decorator).
+--skip-decorator | [string] | Optional. Ignore one or more decorators. See the [Skip decorator section](#skip-decorator)
 --upsert, -u | boolean | Optional. Upsert an API to the API registry. See [the Upsert an API with push section](#upsert-an-api-with-push) for more information.  |
 --version     | boolean | Optional. Show version number.  |
 --region,-r    | string | Optional. Specify which region to use when logging in. Supported values: `us`, `eu`. Default value is `us`. Read more about [configuring the region](../configuration/configuration-file.mdx#region).
-
 
 ## Examples
 
@@ -98,7 +96,6 @@ You can choose any of the following approaches:
 
 - [Specify all options explicitly in the command](#set-options-explicitly)
 - [Set options in the Redocly configuration file](#set-options-in-the-configuration-file)
-
 
 ### Destination
 
@@ -164,7 +161,6 @@ The version of your API should contain only supported characters (`a-z`, `A-Z`, 
 
 :::
 
-
 ### Set options explicitly
 
 Provide the `entrypoint` as a path to the root API definition file, and specify the organization ID, API name and version.
@@ -214,7 +210,6 @@ You must specify your organization ID in the configuration file for this approac
 Push the specified API and version from the `apis` section of the configuration file to the Workflows organization matching the provided organization ID.
 In this case, you don't have to specify the organization ID in the configuration file.
 
-
 ### Upsert an API with push
 
 To upsert an API in the registry with the `push` command, use the `--upsert` or `-u` option.
@@ -241,7 +236,6 @@ openapi push openapi/petstore.yaml @openapi-org/petstore-api@v1 -b develop
 openapi push -u test-api@v1 -b develop
 ```
 
-
 ### Run ID
 
 The `--run-id` option can be used by Redocly Workflows to associate multiple pushes with a single CI job. It is auto-populated for the following CI systems so you don't have to pass it separately:
@@ -263,6 +257,9 @@ You may want to skip specific decorators upon running the command.
 openapi push openapi/petstore.yaml @openapi-org/petstore-api@v1 --skip-decorator=test/remove-internal-operations
 ```
 
+```bash Skip multiple decorators
+openapi push openapi/petstore.yaml @openapi-org/petstore-api@v1 --skip-decorator=test/remove-internal-operations --skip-decorator=test/remove-internal-schemas
+```
 
 ### Set up CI from Redocly Workflows
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "npm run typecheck && npm run unit",
     "unit": "jest ./packages --coverage --coverageReporters lcov text-summary",
     "typecheck": "tsc --noEmit --skipLibCheck",
-    "e2e": "jest ./__tests__",
+    "e2e": "jest --roots=./__tests__/",
     "prettier": "npx prettier --write \"**/*.{ts,js}\"",
     "clean": "rm -rf packages/**/lib packages/**/node_modules packages/**/*.tsbuildinfo package-lock.json node_modules",
     "watch": "tsc -b tsconfig.build.json --watch ",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,7 @@
   "engineStrict": true,
   "scripts": {
     "compile": "tsc",
-    "copy-assets": "cp src/commands/preview-docs/preview-server/default.hbs lib/commands/preview-docs/preview-server/default.hbs && cp src/commands/preview-docs/preview-server/hot.js lib/commands/preview-docs/preview-server/hot.js",
+    "copy-assets": "cp src/commands/preview-docs/preview-server/default.hbs lib/commands/preview-docs/preview-server/default.hbs && cp src/commands/preview-docs/preview-server/hot.js lib/commands/preview-docs/preview-server/hot.js && cp src/commands/preview-docs/preview-server/oauth2-redirect.html lib/commands/preview-docs/preview-server/oauth2-redirect.html",
     "prepublishOnly": "npm run copy-assets"
   },
   "repository": {

--- a/packages/cli/src/__tests__/commands/push-region.test.ts
+++ b/packages/cli/src/__tests__/commands/push-region.test.ts
@@ -1,3 +1,4 @@
+import { getMergedConfig } from '@redocly/openapi-core';
 import { handlePush } from '../../commands/push';
 import { promptClientToken } from '../../commands/login';
 
@@ -6,6 +7,8 @@ jest.mock('node-fetch');
 jest.mock('@redocly/openapi-core');
 jest.mock('../../commands/login');
 jest.mock('../../utils');
+
+(getMergedConfig as jest.Mock).mockImplementation((config) => config);
 
 const mockPromptClientToken = promptClientToken as jest.MockedFunction<typeof promptClientToken>;
 
@@ -23,7 +26,7 @@ describe('push-with-region', () => {
       upsert: true,
       entrypoint: 'spec.json',
       destination: '@org/my-api@1.0.0',
-      branchName: 'test'
+      branchName: 'test',
     });
     expect(mockPromptClientToken).toBeCalledTimes(1);
     expect(mockPromptClientToken).toHaveBeenCalledWith(redoclyClient.domain);
@@ -35,7 +38,7 @@ describe('push-with-region', () => {
       upsert: true,
       entrypoint: 'spec.json',
       destination: '@org/my-api@1.0.0',
-      branchName: 'test'
+      branchName: 'test',
     });
     expect(mockPromptClientToken).toBeCalledTimes(1);
     expect(mockPromptClientToken).toHaveBeenCalledWith(redoclyClient.domain);

--- a/packages/cli/src/__tests__/commands/push.test.ts
+++ b/packages/cli/src/__tests__/commands/push.test.ts
@@ -1,10 +1,17 @@
-import { Config } from '@redocly/openapi-core';
-import { getApiEntrypoint, getDestinationProps, handlePush, transformPush } from '../../commands/push';
+import { Config, getMergedConfig } from '@redocly/openapi-core';
+import {
+  getApiEntrypoint,
+  getDestinationProps,
+  handlePush,
+  transformPush,
+} from '../../commands/push';
 
 jest.mock('fs');
 jest.mock('node-fetch');
 jest.mock('@redocly/openapi-core');
 jest.mock('../../utils');
+
+(getMergedConfig as jest.Mock).mockImplementation((config) => config);
 
 describe('push', () => {
   const redoclyClient = require('@redocly/openapi-core').__redoclyClient;

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -14,6 +14,7 @@ import {
   getTotals,
   slash,
   Region,
+  getMergedConfig,
 } from '@redocly/openapi-core';
 import {
   exitWithError,
@@ -85,11 +86,14 @@ export async function handlePush(argv: PushArgs): Promise<void> {
   const apis = entrypoint ? { [`${name}@${version}`]: { root: entrypoint } } : config.apis;
 
   for (const [apiNameAndVersion, { root: entrypoint }] of Object.entries(apis)) {
+    const resolvedConfig = getMergedConfig(config, entrypoint);
+    resolvedConfig.lint.skipDecorators(argv['skip-decorator']);
+
     const [name, version = DEFAULT_VERSION] = apiNameAndVersion.split('@');
     try {
       let rootFilePath = '';
       const filePaths: string[] = [];
-      const filesToUpload = await collectFilesToUpload(entrypoint, config);
+      const filesToUpload = await collectFilesToUpload(entrypoint, resolvedConfig);
       const filesHash = hashFiles(filesToUpload.files);
 
       process.stdout.write(

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -81,6 +81,8 @@ export async function handlePush(argv: PushArgs): Promise<void> {
     );
   }
 
+  config.lint.skipDecorators(argv['skip-decorator']);
+
   const apis = entrypoint ? { [`${name}@${version}`]: { root: entrypoint } } : config.apis;
 
   for (const [apiNameAndVersion, { root: entrypoint }] of Object.entries(apis)) {

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -33,6 +33,7 @@ type PushArgs = {
   upsert?: boolean;
   'run-id'?: string;
   region?: Region;
+  'skip-decorator'?: string[];
 };
 
 export async function handlePush(argv: PushArgs): Promise<void> {
@@ -70,6 +71,7 @@ export async function handlePush(argv: PushArgs): Promise<void> {
   }
   const entrypoint =
     argv.entrypoint || (name && version && getApiEntrypoint({ name, version, config }));
+
   if (name && version && !entrypoint) {
     exitWithError(
       `No entrypoint found that matches ${blue(
@@ -77,6 +79,8 @@ export async function handlePush(argv: PushArgs): Promise<void> {
       )}. Please make sure you have provided the correct data in the config file.`,
     );
   }
+
+  config.lint.skipDecorators(argv['skip-decorator']);
 
   const apis = entrypoint ? { [`${name}@${version}`]: { root: entrypoint } } : config.apis;
 

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -81,8 +81,6 @@ export async function handlePush(argv: PushArgs): Promise<void> {
     );
   }
 
-  config.lint.skipDecorators(argv['skip-decorator']);
-
   const apis = entrypoint ? { [`${name}@${version}`]: { root: entrypoint } } : config.apis;
 
   for (const [apiNameAndVersion, { root: entrypoint }] of Object.entries(apis)) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -101,6 +101,11 @@ yargs
           upsert: { type: 'boolean', alias: 'u' },
           'run-id': { type: 'string', requiresArg: true },
           region: { description: 'Specify a region.', alias: 'r', choices: regionChoices },
+          'skip-decorator': {
+            description: 'Ignore certain decorators.',
+            array: true,
+            type: 'string',
+          },
         }),
     transformPush(handlePush),
   )


### PR DESCRIPTION
## What/Why/How?

This PR does two main things: 
* Adds `--skip-decorator` option to the `push` command
* Adds support for multiple API definitions in `.redocly.yaml` using `getMergedConfig` function

Additionally, a small change that makes sure `npm run e2e` only runs tests in the `__tests__` directory in the root of the project.

## Reference

Resolves https://github.com/Redocly/workflows/issues/1387

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
