### PR TITLE
hotfix: fix getMergedConfig to keep config file location

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -646,19 +646,22 @@ function assignExisting<T>(target: Record<string, T>, obj: Record<string, T>) {
 
 export function getMergedConfig(config: Config, entrypointAlias?: string): Config {
   return entrypointAlias
-    ? new Config({
-        ...config.rawConfig,
-        lint: getMergedLintConfig(config, entrypointAlias),
-        'features.openapi': {
-          ...config['features.openapi'],
-          ...config.apis[entrypointAlias]?.['features.openapi'],
+    ? new Config(
+        {
+          ...config.rawConfig,
+          lint: getMergedLintConfig(config, entrypointAlias),
+          'features.openapi': {
+            ...config['features.openapi'],
+            ...config.apis[entrypointAlias]?.['features.openapi'],
+          },
+          'features.mockServer': {
+            ...config['features.mockServer'],
+            ...config.apis[entrypointAlias]?.['features.mockServer'],
+          },
+          // TODO: merge everything else here
         },
-        'features.mockServer': {
-          ...config['features.mockServer'],
-          ...config.apis[entrypointAlias]?.['features.mockServer'],
-        },
-        // TODO: merge everything else here
-      })
+        config.configFile,
+      )
     : config;
 }
 


### PR DESCRIPTION
## What/Why/How?

Push command skips any dependencies because the merged config loses the original config filename and there is a check here: https://github.com/Redocly/openapi-cli/blob/hotfix-get-merged-config/packages/cli/src/commands/push.ts#L224

## Reference

Reported by customer.

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
