### PR TITLE
feat: merge plugins by unique paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   },
   "jest": {
     "clearMocks": true,
+    "restoreMocks": true,
     "preset": "ts-jest",
     "collectCoverageFrom": [
       "packages/**/*.ts",

--- a/packages/cli/src/__tests__/commands/bundle.test.ts
+++ b/packages/cli/src/__tests__/commands/bundle.test.ts
@@ -12,7 +12,7 @@ describe('bundle', () => {
   let processExitMock: SpyInstance;
   let exitCb: any;
 
-  beforeAll(() => {
+  beforeEach(() => {
     processExitMock = jest.spyOn(process, 'exit').mockImplementation();
     jest.spyOn(process, 'once').mockImplementation((_e, cb) => {
       exitCb = cb;

--- a/packages/core/src/config/__tests__/load.test.ts
+++ b/packages/core/src/config/__tests__/load.test.ts
@@ -100,7 +100,7 @@ describe('resolveNestedPlugins', () => {
 
 describe('getConfig', () => {
   jest.spyOn(fs, 'hasOwnProperty').mockImplementation(() => false);
-  it('should return empty object if there is no configPath', () => {
+  it('should return empty object if there is no configPath and config file is not found', () => {
     expect(getConfig()).toEqual(Promise.resolve({}));
   });
 });

--- a/packages/core/src/config/__tests__/load.test.ts
+++ b/packages/core/src/config/__tests__/load.test.ts
@@ -1,4 +1,4 @@
-import { loadConfig, findConfig, resolveNestedPlugins } from '../load';
+import { loadConfig, findConfig, resolveNestedPlugins, getConfig } from '../load';
 import { RedoclyClient } from '../../redocly';
 
 const fs = require('fs');
@@ -95,5 +95,12 @@ describe('resolveNestedPlugins', () => {
   it('should resolve plugin path when plugin has same level like nested config path', () => {
     const path = resolveNestedPlugins({ ...testData, plugin: 'test-plugin.js' });
     expect(path).toStrictEqual('/api/test-plugin.js');
+  });
+});
+
+describe('getConfig', () => {
+  jest.spyOn(fs, 'hasOwnProperty').mockImplementation(() => false);
+  it('should return empty object if there is no configPath', () => {
+    expect(getConfig()).toEqual(Promise.resolve({}));
   });
 });

--- a/packages/core/src/config/__tests__/merged-rules-by-priority.test.ts
+++ b/packages/core/src/config/__tests__/merged-rules-by-priority.test.ts
@@ -120,5 +120,24 @@ describe('getLintRawConfigWithMergedContentByPriority', () => {
     expect(getLintRawConfigWithMergedContentByPriority(input)).toEqual(result);
   });
 
-  //   TODO: test also other extends (like recommended), as well as plugins, decorators, preprocessors
+  it('should merge plugins taking into account unique path', () => {
+    const input: ResolvedLintRawConfig = {
+      extends: [
+        { plugins: ['./plugin-1.js'] },
+        { plugins: ['./plugin-2.js'] },
+        { plugins: [{ id: 'some-id' }] },
+      ],
+      plugins: ['./plugin-1.js', './plugin-3.js'],
+    };
+
+    const result: LintRawConfig = {
+      extends: [],
+      rules: {},
+      preprocessors: {},
+      decorators: {},
+      plugins: ['./plugin-2.js', { id: 'some-id' }, './plugin-1.js', './plugin-3.js'],
+    };
+
+    expect(getLintRawConfigWithMergedContentByPriority(input)).toEqual(result);
+  });
 });

--- a/packages/core/src/config/__tests__/merged-rules-by-priority.test.ts
+++ b/packages/core/src/config/__tests__/merged-rules-by-priority.test.ts
@@ -120,7 +120,7 @@ describe('getLintRawConfigWithMergedContentByPriority', () => {
     expect(getLintRawConfigWithMergedContentByPriority(input)).toEqual(result);
   });
 
-  it('should merge plugins taking into account unique path', () => {
+  it('should merge plugins taking into account unique paths', () => {
     const input: ResolvedLintRawConfig = {
       extends: [
         { plugins: ['./plugin-1.js'] },
@@ -135,7 +135,7 @@ describe('getLintRawConfigWithMergedContentByPriority', () => {
       rules: {},
       preprocessors: {},
       decorators: {},
-      plugins: ['./plugin-2.js', { id: 'some-id' }, './plugin-1.js', './plugin-3.js'],
+      plugins: ['./plugin-1.js', './plugin-2.js', { id: 'some-id' }, './plugin-3.js'],
     };
 
     expect(getLintRawConfigWithMergedContentByPriority(input)).toEqual(result);

--- a/packages/core/src/config/load.ts
+++ b/packages/core/src/config/load.ts
@@ -4,7 +4,7 @@ import { RedoclyClient } from '../redocly';
 import { isEmptyArray, isNotString, isString, loadYaml, mergeArrays, parseYaml } from '../utils';
 import { Config, DOMAINS } from './config';
 import { defaultPlugin } from './builtIn';
-import { getResolveConfig, getUniquePlugins, transformConfig } from './utils';
+import { getResolveConfig, transformConfig } from './utils';
 import { isAbsoluteUrl } from '../ref-utils';
 import { BaseResolver } from '../resolve';
 
@@ -137,8 +137,7 @@ export function getLintRawConfigWithMergedContentByPriority(
 
   return {
     ...lintConfig,
-    plugins: getUniquePlugins(mergeArrays(extendedContent?.plugins, lintConfig.plugins)),
-    // TODO: think about unique default rules/plugins group
+    plugins: [...new Set(mergeArrays(extendedContent?.plugins, lintConfig.plugins))],
     extends: extendedContent?.extends,
     rules: { ...extendedContent?.rules, ...lintConfig.rules },
     preprocessors: { ...extendedContent?.preprocessors, ...lintConfig.preprocessors },

--- a/packages/core/src/config/load.ts
+++ b/packages/core/src/config/load.ts
@@ -4,7 +4,7 @@ import { RedoclyClient } from '../redocly';
 import { isEmptyArray, isNotString, isString, loadYaml, mergeArrays, parseYaml } from '../utils';
 import { Config, DOMAINS } from './config';
 import { defaultPlugin } from './builtIn';
-import { getResolveConfig, transformConfig } from './utils';
+import { getResolveConfig, getUniquePlugins, transformConfig } from './utils';
 import { isAbsoluteUrl } from '../ref-utils';
 import { BaseResolver } from '../resolve';
 
@@ -137,7 +137,7 @@ export function getLintRawConfigWithMergedContentByPriority(
 
   return {
     ...lintConfig,
-    plugins: mergeArrays(extendedContent?.plugins, lintConfig.plugins), // FIXME: plugins should be uniq
+    plugins: getUniquePlugins(mergeArrays(extendedContent?.plugins, lintConfig.plugins)),
     // TODO: think about unique default rules/plugins group
     extends: extendedContent?.extends,
     rules: { ...extendedContent?.rules, ...lintConfig.rules },

--- a/packages/core/src/config/utils.ts
+++ b/packages/core/src/config/utils.ts
@@ -292,7 +292,3 @@ export function getResolveConfig(resolve?: RawResolveConfig): ResolveConfig {
     },
   };
 }
-
-export function getUniquePlugins(plugins: (string | Plugin)[]): (string | Plugin)[] {
-  return [...new Set(plugins.reverse())].reverse();
-}

--- a/packages/core/src/config/utils.ts
+++ b/packages/core/src/config/utils.ts
@@ -292,3 +292,7 @@ export function getResolveConfig(resolve?: RawResolveConfig): ResolveConfig {
     },
   };
 }
+
+export function getUniquePlugins(plugins: (string | Plugin)[]): (string | Plugin)[] {
+  return [...new Set(plugins.reverse())].reverse();
+}


### PR DESCRIPTION
## What/Why/How?

We have to merge plugins in a way that should avoid duplication (they should be unique for each path). For this, I'm leaving only the last entry of each unique plugin path. Entries of type `Plugin` remain unchanged.
> Additionally:
> + Updated tests settings.
> + Added one not related test (for `getConfig` function).

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
