### PR TITLE
chore: improve deploy-local

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "benchmark": "node --expose-gc --noconcurrent_sweeping --predictable packages/core/src/benchmark/benchmark.js",
     "webpack-bundle": "webpack --config webpack.config.ts",
     "upload": "node scripts/archive-and-upload-bundle.js",
-    "deploy-local": "npm run compile && ENV=local npm run upload"
+    "deploy-local": "npm run webpack-bundle && npm run compile && ENV=local npm run upload"
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## What/Why/How?
`deploy-local` script hardly depends on `dist` already precent.
So `build:webpack` is mandatory step for that

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
