### PR TITLE
chore: bump to v1.0.0-beta.95

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,20 @@ tocMaxDepth: 2
 
 # OpenAPI CLI changelog
 
+## 1.0.0-beta-95 (2022-05-04)
+
+### Features
+
+- Added support for files in Redocly config `extends` section.
+- Added codeclimate formating for lint command.
+- Internal changes.
+
+### Fixes
+
+- Fixed resolving scalar values in asserts.
+
+---
+
 ## 1.0.0-beta-94 (2022-04-12)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redocly/openapi",
-  "version": "1.0.0-beta.94",
+  "version": "1.0.0-beta.95",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@redocly/openapi",
-      "version": "1.0.0-beta.94",
+      "version": "1.0.0-beta.95",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -10122,10 +10122,10 @@
     },
     "packages/cli": {
       "name": "@redocly/openapi-cli",
-      "version": "1.0.0-beta.94",
+      "version": "1.0.0-beta.95",
       "license": "MIT",
       "dependencies": {
-        "@redocly/openapi-core": "1.0.0-beta.94",
+        "@redocly/openapi-core": "1.0.0-beta.95",
         "@types/node": "^14.11.8",
         "assert-node-version": "^1.0.3",
         "chokidar": "^3.5.1",
@@ -10155,7 +10155,7 @@
     },
     "packages/core": {
       "name": "@redocly/openapi-core",
-      "version": "1.0.0-beta.94",
+      "version": "1.0.0-beta.95",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.6.4",
@@ -10894,7 +10894,7 @@
     "@redocly/openapi-cli": {
       "version": "file:packages/cli",
       "requires": {
-        "@redocly/openapi-core": "1.0.0-beta.94",
+        "@redocly/openapi-core": "1.0.0-beta.95",
         "@types/node": "^14.11.8",
         "@types/yargs": "16.0.2",
         "assert-node-version": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/openapi",
-  "version": "1.0.0-beta.94",
+  "version": "1.0.0-beta.95",
   "description": "",
   "private": true,
   "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/openapi-cli",
-  "version": "1.0.0-beta.94",
+  "version": "1.0.0-beta.95",
   "description": "",
   "license": "MIT",
   "bin": {
@@ -34,7 +34,7 @@
     "Andriy Leliv <andriy@redoc.ly> (https://redoc.ly/)"
   ],
   "dependencies": {
-    "@redocly/openapi-core": "1.0.0-beta.94",
+    "@redocly/openapi-core": "1.0.0-beta.95",
     "@types/node": "^14.11.8",
     "assert-node-version": "^1.0.3",
     "chokidar": "^3.5.1",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@redocly/openapi-core",
-  "version": "1.0.0-beta.93",
+  "version": "1.0.0-beta.95",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@redocly/openapi-core",
-      "version": "1.0.0-beta.93",
+      "version": "1.0.0-beta.95",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.6.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/openapi-core",
-  "version": "1.0.0-beta.94",
+  "version": "1.0.0-beta.95",
   "description": "",
   "main": "lib/index.js",
   "engines": {


### PR DESCRIPTION
## What/Why/How?
- Fixed resolving scalar values in asserts (#646) 
- Added fixtures for resolving remote configs (#654)
- Added support for files in Redocly config `extends` section (#616)
- Added codeclimate formating for lint command (#669)
- Updated config to use with Webpack 5 (#671)

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
