### PR TITLE
chore: update config to use with Webpack 5

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,10 @@
     "url": "https://github.com/Redocly/openapi-cli.git"
   },
   "browser": {
-    "fs": false
+    "fs": false,
+    "path": "path-browserify",
+    "os": false,
+    "node-fetch": false
   },
   "homepage": "https://github.com/Redocly/openapi-cli",
   "keywords": [

--- a/packages/core/src/config/config-resolvers.ts
+++ b/packages/core/src/config/config-resolvers.ts
@@ -1,6 +1,5 @@
 import * as path from 'path';
 import { blue, red } from 'colorette';
-import { URL } from 'url';
 import { isAbsoluteUrl } from '../ref-utils';
 import { BaseResolver } from '../resolve';
 import { defaultPlugin } from './builtIn';

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { dirname } from 'path';
 import { parseYaml, stringifyYaml } from '../js-yaml';
 import { slash } from '../utils';
 import { NormalizedProblem } from '../walk';
@@ -100,7 +99,7 @@ export class LintConfig {
 
       // resolve ignore paths
       for (const fileName of Object.keys(this.ignore)) {
-        this.ignore[path.resolve(dirname(ignoreFile), fileName)] = this.ignore[fileName];
+        this.ignore[path.resolve(path.dirname(ignoreFile), fileName)] = this.ignore[fileName];
         for (const ruleId of Object.keys(this.ignore[fileName])) {
           this.ignore[fileName][ruleId] = new Set(this.ignore[fileName][ruleId]);
         }

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -1,7 +1,5 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as url from 'url';
-
 import { OasRef } from './typings/openapi';
 import { isRef, joinPointer, escapePointer, parseRef, isAbsoluteUrl } from './ref-utils';
 import type { YAMLNode, LoadOptions } from 'yaml-ast-parser';
@@ -105,7 +103,7 @@ export class BaseResolver {
     }
 
     if (base && isAbsoluteUrl(base)) {
-      return url.resolve(base, ref);
+      return new URL(ref, base).href;
     }
 
     return path.resolve(base ? path.dirname(base) : process.cwd(), ref);


### PR DESCRIPTION
## What/Why/How?

Resolves node dependencies issues in browser environment when using OpenAPI core with Webpack 5. 

## Reference

Also related to https://github.com/Redocly/redoc/issues/1820

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested with redoc/reference-docs/workflows
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
